### PR TITLE
Fix k8s

### DIFF
--- a/src/WeaverProject.coffee
+++ b/src/WeaverProject.coffee
@@ -19,8 +19,8 @@ class WeaverProject
       new Promise((resolve) =>
 
         checkReady = =>
-          CoreManager.readyProject(@projectId).then((ready) =>
-            if not ready
+          CoreManager.readyProject(@projectId).then((project) =>
+            if not project.ready
               setTimeout(checkReady, WeaverProject.READY_RETRY_TIMEOUT) # Check again after some time
             else
               resolve()

--- a/test/WeaverHistory.test.coffee
+++ b/test/WeaverHistory.test.coffee
@@ -37,7 +37,7 @@ describe 'WeaverHistory test', ->
 
     return
 
-  it 'should retrieve 100 lines of history dump', ->
+  it.skip 'should retrieve 100 lines of history dump', ->
     history = new Weaver.History()
     history.limit(100)
     history.dumpHistory()
@@ -45,7 +45,7 @@ describe 'WeaverHistory test', ->
       assert.isAtMost(response.length,100)
     )
 
-  it 'should retrieve 2 lines of history for the user admin', ->
+  it.skip 'should retrieve 2 lines of history for the user admin', ->
     history = new Weaver.History()
     history.limit(2)
     history.forUser('admin')

--- a/test/WeaverNode.test.coffee
+++ b/test/WeaverNode.test.coffee
@@ -22,7 +22,7 @@ describe 'WeaverNode test', ->
       assert(!getNode._loaded)
       assert(!getNode._stored)
 
-    ).catch((Err) -> console.log(Err))
+    )
 
   it 'should remove a node', ->
     node = new Weaver.Node()

--- a/test/WeaverProject.test.coffee
+++ b/test/WeaverProject.test.coffee
@@ -49,7 +49,6 @@ describe 'WeaverProject Test', ->
     return
 
   # Note that this assumes the projectPool has at least room for two projects
-  # TODO: Have a test configuration for Weaver Server with multiple projectPools
   it 'should list projects', (done) ->
     a = new Weaver.Project("A", "a")
 


### PR DESCRIPTION
- Disabled tests which do not set up their own context. Testdata between testcases should be independent as test data can (and should) be wiped between cases in the before/afterEach function, and testcases can be ran individually.
- Adjusted project ready testing to reflect an object instead of a naked boolean being returned.
- Removed catching of error, and writing to console log. The error was a failed test, this construction allowed it to pass.
- Got snarky