### PR TITLE
Removes Promise and cuid from the global namespace

### DIFF
--- a/src/WeaverACL.coffee
+++ b/src/WeaverACL.coffee
@@ -1,3 +1,4 @@
+cuid        = require('cuid')
 WeaverRoot  = require('./WeaverRoot')
 
 

--- a/src/WeaverRelation.coffee
+++ b/src/WeaverRelation.coffee
@@ -1,3 +1,4 @@
+cuid = require('cuid')
 Operation = require('./Operation')
 WeaverRoot  = require('./WeaverRoot')
 

--- a/test/WeaverHistory.test.coffee
+++ b/test/WeaverHistory.test.coffee
@@ -2,9 +2,6 @@ weaver = require("./test-suite")
 Weaver = weaver.getClass()
 
 describe 'WeaverHistory test', ->
-
-
-
   it 'should set a new string attribute', ->
     node = new Weaver.Node()
     nodeB = new Weaver.Node()

--- a/test/WeaverRelation.test.coffee
+++ b/test/WeaverRelation.test.coffee
@@ -1,7 +1,7 @@
 weaver = require("./test-suite")
 Weaver = weaver.getClass()
 
-describe 'WeaverNode relation and WeaverRelationNode test', ->
+describe 'Weaver relation and WeaverRelationNode test', ->
 
   it 'should add a new relation without id', ->
     foo = new Weaver.Node()

--- a/test/WeaverUser.test.coffee
+++ b/test/WeaverUser.test.coffee
@@ -1,4 +1,5 @@
 weaver = require("./test-suite")
+cuid   = require('cuid')
 Weaver = weaver.getClass()
 
 describe 'WeaverUser Test', ->

--- a/test/globalize.coffee
+++ b/test/globalize.coffee
@@ -12,8 +12,6 @@ chai.use(require('chai-as-promised'));
 chai.should();
 
 # From libs
-global.Promise = Promise
-global.cuid    = cuid
 global.expect  = chai.expect
 global.assert  = chai.assert
 global.should  = chai.should


### PR DESCRIPTION
Removing non-dev dependencies from global namespace in testing. This fixes that these globals are not available in non-test environments.