### PR TITLE
Adds the server-version checking functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/weaverplatform/weaver-sdk-js",
     "email": "mohamad@sysunite.com"
   },
+  "com_weaverplatform": {
+    "requiredServerVersion": "~2.2.5 || ~2.2.9-beta"
+  },
   "main": "lib/Weaver.js",
   "license": "GPL-3.0",
   "repository": {},

--- a/src/SocketController.coffee
+++ b/src/SocketController.coffee
@@ -10,7 +10,7 @@ class SocketController
       reconnection: true
 
     @options = @options or defaultOptions
-    @options.query = "sdkVersion=#{pjson.version}"
+    @options.query = "sdkVersion=#{pjson.version}&requiredServerVersion=#{pjson.com_weaverplatform.requiredServerVersion}"
 
   connect: ->
     new Promise((resolve, reject) =>


### PR DESCRIPTION
This adds the server-version checking functionality. 

Note that the requiredServerVersion in the package.json includes an or clause since prerelease tags never satisify a non-prerelease version. In testing before an official release, this check should be removed (release procedure will be updated to reflect that).
