### PR TITLE
Issue 82 project list

### DIFF
--- a/src/WeaverProject.coffee
+++ b/src/WeaverProject.coffee
@@ -5,10 +5,9 @@ class WeaverProject
 
   @READY_RETRY_TIMEOUT: 200
 
-  constructor: (@name, @projectId) ->
+  constructor: (@name, @projectId, @_stored = false) ->
     @name = @name or 'unnamed'
     @projectId = @projectId or cuid()
-    @_stored = false
 
   id: ->
     @projectId
@@ -59,6 +58,8 @@ class WeaverProject
     Weaver.getCoreManager().getACL(@projectId)
 
   @list: ->
-    Weaver.getCoreManager().listProjects()
+    Weaver.getCoreManager().listProjects().then((list) ->
+      ( new Weaver.Project(p.id, p.name, true) for p in list )
+    )
 
 module.exports = WeaverProject

--- a/test/WeaverProject.test.coffee
+++ b/test/WeaverProject.test.coffee
@@ -2,6 +2,19 @@ weaver = require("./test-suite")
 Weaver = require('../src/Weaver')
 
 describe 'WeaverProject Test', ->
+  actualProject = (p) ->
+    expect(p).to.have.property('_stored').to.be.a('boolean').to.equal(true)
+    expect(p).to.have.property('destroy').be.a('function')
+
+  it 'should have currentProject be not neutered', ->
+    actualProject(weaver.currentProject())
+
+  it 'should list projects that are not neutered', ->
+    Weaver.Project.list().then((list) ->
+      expect(list).to.have.length.be(1)
+      actualProject(list[0])
+    )
+
   it.skip 'should create projects with given id', (done) ->
     project = new Weaver.Project("name", "test")
     project.create().then((p) =>


### PR DESCRIPTION
Fixes Weaver.Project.list() to return functional Projects, which can be destroyed and used in useProject etc.