### PR TITLE
Adds test to show ACL check on file uploads

### DIFF
--- a/src/WeaverFile.coffee
+++ b/src/WeaverFile.coffee
@@ -28,7 +28,7 @@ class WeaverFile
           resolve(fileStream.path)
         )
       catch error
-        reject(Error WeaverError.OTHER_CAUSE,"Something went wrong")
+        reject(Error WeaverError.OTHER_CAUSE,error)
     )
 
   deleteFileByID: (id) ->


### PR DESCRIPTION
Adds test illustrating that the server rejects unauthorised access to attachments. Server functionality to reject these is already present in 2.3.2 or prior, this is just a test to prove it. 