### PR TITLE
Load all nodes in a relation

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "weaver-sdk",
   "main": "dist/weaver-sdk.full.js",
-  "version": "2.3.3-beta.2",
+  "version": "2.3.3-beta.3",
   "homepage": "https://github.com/weaverplatform/weaver-sdk-js",
   "authors": [
     "Mohamad Alamili <mohamad@sysunite.com>"

--- a/dist/weaver-sdk.full.js
+++ b/dist/weaver-sdk.full.js
@@ -99012,7 +99012,7 @@ module.exports = yeast;
 },{}],391:[function(require,module,exports){
 module.exports={
   "name": "weaver-sdk",
-  "version": "2.3.3-beta.1",
+  "version": "2.3.3-beta.2",
   "description": "Weaver SDK for JavaScript",
   "author": {
     "name": "Mohamad Alamili",
@@ -101141,7 +101141,17 @@ module.exports={
     }
 
     WeaverRelation.prototype.load = function() {
-      return Promise.resolve([]);
+      var key, node;
+      return Promise.all((function() {
+        var ref, results;
+        ref = this.nodes;
+        results = [];
+        for (key in ref) {
+          node = ref[key];
+          results.push(node.load());
+        }
+        return results;
+      }).call(this));
     };
 
     WeaverRelation.prototype.query = function() {

--- a/dist/weaver-sdk.full.js
+++ b/dist/weaver-sdk.full.js
@@ -99012,7 +99012,7 @@ module.exports = yeast;
 },{}],391:[function(require,module,exports){
 module.exports={
   "name": "weaver-sdk",
-  "version": "2.3.3-beta.2",
+  "version": "2.3.3-beta.3",
   "description": "Weaver SDK for JavaScript",
   "author": {
     "name": "Mohamad Alamili",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weaver-sdk",
-  "version": "2.3.3-beta.2",
+  "version": "2.3.3-beta.3",
   "description": "Weaver SDK for JavaScript",
   "author": {
     "name": "Mohamad Alamili",

--- a/src/WeaverRelation.coffee
+++ b/src/WeaverRelation.coffee
@@ -10,7 +10,7 @@ class WeaverRelation
     @relationNodes = {}   # Map node id to RelationNode
 
   load: ->
-    Promise.resolve([])
+    Promise.all((node.load() for key, node of @nodes))
 
   query: ->
     Promise.resolve([])

--- a/test/WeaverRelation.test.coffee
+++ b/test/WeaverRelation.test.coffee
@@ -104,4 +104,18 @@ describe 'Weaver relation and WeaverRelationNode test', ->
       assert.lengthOf(relations, 1)
     )
 
+  it 'should load all nodes in the relation', ->
+    foo = new Weaver.Node()
+    bar = new Weaver.Node()
+    ono = new Weaver.Node()
+    foo.relation('comesBefore').add(bar)
+    foo.relation('comesBefore').add(ono)
 
+    foo.save().then(->
+      Weaver.Node.load(foo.id())
+    ).then((loadedNode) ->
+      assert.isFalse(node._loaded) for node in loadedNode.relation('comesBefore').all()
+      loadedNode.relation('comesBefore').load()
+    ).then((nodes) ->
+      assert.isTrue(node._loaded) for node in nodes
+    )


### PR DESCRIPTION
We can now load all nodes in a relation by doing

```js
node.relation('someRelation').load()
.then((nodes) => {
  //array of loaded nodes
})
```