### PR TITLE
Weaver Relation Fix

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "weaver-sdk",
   "main": "dist/weaver-sdk.full.js",
-  "version": "3.0.5-beta.0",
+  "version": "3.0.5-beta.1",
   "homepage": "https://github.com/weaverplatform/weaver-sdk-js",
   "authors": [
     "Mohamad Alamili <mohamad@sysunite.com>"

--- a/dist/weaver-sdk.full.js
+++ b/dist/weaver-sdk.full.js
@@ -99012,7 +99012,7 @@ module.exports = yeast;
 },{}],391:[function(require,module,exports){
 module.exports={
   "name": "weaver-sdk",
-  "version": "3.0.5-beta.0",
+  "version": "3.0.5-beta.1",
   "description": "Weaver SDK for JavaScript",
   "author": {
     "name": "Mohamad Alamili",
@@ -101277,7 +101277,16 @@ module.exports={
     }
 
     WeaverRelation.prototype.load = function() {
-      return new Weaver.Query().hasRelationIn(this.key, this.parent).find();
+      return new Weaver.Query().hasRelationIn(this.key, this.parent).find().then((function(_this) {
+        return function(nodes) {
+          var i, len, node;
+          for (i = 0, len = nodes.length; i < len; i++) {
+            node = nodes[i];
+            _this.nodes[node.id()] = node;
+          }
+          return _this.nodes;
+        };
+      })(this));
     };
 
     WeaverRelation.prototype.query = function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weaver-sdk",
-  "version": "3.0.5-beta.0",
+  "version": "3.0.5-beta.1",
   "description": "Weaver SDK for JavaScript",
   "author": {
     "name": "Mohamad Alamili",

--- a/src/WeaverRelation.coffee
+++ b/src/WeaverRelation.coffee
@@ -11,6 +11,10 @@ class WeaverRelation
 
   load: ->
     new Weaver.Query().hasRelationIn(@key, @parent).find()
+      .then((nodes) =>
+        @nodes[node.id()] = node for node in nodes
+        @nodes
+      )
 
   query: ->
     Promise.resolve([])

--- a/test/WeaverRelation.test.coffee
+++ b/test/WeaverRelation.test.coffee
@@ -109,11 +109,12 @@ describe 'Weaver relation and WeaverRelationNode test', ->
 
     foo.save().then(->
       Weaver.Node.load(foo.id())
-    ).then((loadedNode) ->
-      assert.isFalse(node._loaded) for node in loadedNode.relation('comesBefore').all()
-      loadedNode.relation('comesBefore').load()
+    ).then(->
+      assert.isFalse(node._loaded) for node in foo.relation('comesBefore').all()
+      foo.relation('comesBefore').load()
     ).then((nodes) ->
       assert.isTrue(node._loaded) for node in nodes
+      assert.isTrue(node._loaded) for node in foo.relation('comesBefore').all()
     )
 
   it 'should return the first node in a relation', ->


### PR DESCRIPTION
Important fix for relations. All nodes that were loaded through the load function in WeaverRelation were not updates inside the relation itself. This fixes that issue.