### PR TITLE
Weaver query 2.0

### DIFF
--- a/src/WeaverQuery.coffee
+++ b/src/WeaverQuery.coffee
@@ -105,20 +105,31 @@ class WeaverQuery
     @_addCondition(key, '$gte', value)
 
   hasRelationIn: (key, node...) ->
-    @_addCondition(key, '$relIn', if node.length > 0 then (i.id() for i in node) else ['*']);
+    if node.length is 1 and node[0] instanceof WeaverQuery
+      @_addCondition(key, '$relIn', node)
+    else
+      @_addCondition(key, '$relIn', if node.length > 0 then (i.id() or i for i in node) else ['*'])
 
   hasRelationOut: (key, node...) ->
     if _.isArray(key)
       @_relationsOut = key # values are ignored
+    else if node.length is 1 and node[0] instanceof WeaverQuery
+      @_addCondition(key, '$relOut', node)
     else
-      @_addCondition(key, '$relOut', if node.length > 0 then (i.id() for i in node) else ['*']);
+      @_addCondition(key, '$relOut', if node.length > 0 then (i.id() or i for i in node) else ['*'])
     @
 
   hasNoRelationIn: (key, node...) ->
-    @_addCondition(key, '$noRelIn', if node.length > 0 then (i.id() for i in node) else ['*']);
+    if node.length is 1 and node[0] instanceof WeaverQuery
+      @_addCondition(key, '$noRelIn', node)
+    else
+      @_addCondition(key, '$noRelIn', if node.length > 0 then (i.id() or i for i in node) else ['*'])
 
   hasNoRelationOut: (key, node...) ->
-    @_addCondition(key, '$noRelOut', if node.length > 0 then (i.id() for i in node) else ['*']);
+    if node.length is 1 and node[0] instanceof WeaverQuery
+      @_addCondition(key, '$noRelOut', node)
+    else
+      @_addCondition(key, '$noRelOut', if node.length > 0 then (i.id() or i for i in node) else ['*'])
 
   containedIn: (key, values) ->
     @_addCondition(key, '$in', values)

--- a/src/WeaverQuery.coffee
+++ b/src/WeaverQuery.coffee
@@ -6,7 +6,7 @@ _           = require('lodash')
 # Surrounding with \Q .. \E does this, we just need to escape any \E's in
 # the text separately.
 quote = (s) ->
-  '\\Q' + s.replace('\\E', '\\E\\\\E\\Q') + '\\E';
+  '\\Q' + s.replace('\\E', '\\E\\\\E\\Q') + '\\E'
 
 
 class WeaverQuery
@@ -90,19 +90,19 @@ class WeaverQuery
     @
 
   notEqualTo: (key, value) ->
-    @_addCondition(key, '$ne', value);
+    @_addCondition(key, '$ne', value)
 
   lessThan: (key, value) ->
-    @_addCondition(key, '$lt', value);
+    @_addCondition(key, '$lt', value)
 
   greaterThan: (key, value) ->
-    @_addCondition(key, '$gt', value);
+    @_addCondition(key, '$gt', value)
 
   lessThanOrEqualTo: (key, value) ->
-    @_addCondition(key, '$lte', value);
+    @_addCondition(key, '$lte', value)
 
   greaterThanOrEqualTo: (key, value) ->
-    @_addCondition(key, '$gte', value);
+    @_addCondition(key, '$gte', value)
 
   hasRelationIn: (key, node...) ->
     @_addCondition(key, '$relIn', if node.length > 0 then (i.id() for i in node) else ['*']);
@@ -121,43 +121,43 @@ class WeaverQuery
     @_addCondition(key, '$noRelOut', if node.length > 0 then (i.id() for i in node) else ['*']);
 
   containedIn: (key, values) ->
-    @_addCondition(key, '$in', values);
+    @_addCondition(key, '$in', values)
 
   notContainedIn: (key, values) ->
-    @_addCondition(key, '$nin', values);
+    @_addCondition(key, '$nin', values)
 
   containsAll: (key, values) ->
-    @_addCondition(key, '$all', values);
+    @_addCondition(key, '$all', values)
 
   exists: (key) ->
-    @_addCondition(key, '$exists', true);
+    @_addCondition(key, '$exists', true)
 
   doesNotExist: (key) ->
-    @_addCondition(key, '$exists', false);
+    @_addCondition(key, '$exists', false)
 
   matches: (key, value) ->
-    @_addCondition(key, '$regex', value);
+    @_addCondition(key, '$regex', value)
 
   contains: (key, value) ->
-    @_addCondition(key, '$contains', value);
+    @_addCondition(key, '$contains', value)
 
   startsWith: (key, value) ->
-    @_addCondition(key, '$regex', '^' + quote(value));
+    @_addCondition(key, '$regex', '^' + quote(value))
 
   endsWith: (key, value) ->
-    @_addCondition(key, '$regex', quote(value) + '$');
+    @_addCondition(key, '$regex', quote(value) + '$')
 
   matchesQuery: (key, weaverQuery) ->
-    @_addCondition(key, '$inQuery', weaverQuery);
+    @_addCondition(key, '$inQuery', weaverQuery)
 
   doesNotMatchQuery: (key, query) ->
-    @_addCondition(key, '$notInQuery', query);
+    @_addCondition(key, '$notInQuery', query)
 
   matchesKeyQuery: (key, queryKey, query) ->
-    @_addCondition(key, '$select', {queryKey, query});
+    @_addCondition(key, '$select', {queryKey, query})
 
   doesNotMatchKeyInQuery: (key, queryKey, query) ->
-    @_addCondition(key, '$dontSelect', {queryKey, query});
+    @_addCondition(key, '$dontSelect', {queryKey, query})
 
   withAttributes: ->
     @_noAttributes = false

--- a/src/WeaverQuery.coffee
+++ b/src/WeaverQuery.coffee
@@ -1,5 +1,6 @@
 util        = require('./util')
 Weaver      = require('./Weaver')
+_           = require('lodash')
 
 # Converts a string into a regex that matches it.
 # Surrounding with \Q .. \E does this, we just need to escape any \E's in
@@ -15,6 +16,7 @@ class WeaverQuery
     @_equals       = {}
     @_orQueries    = []
     @_conditions   = {}
+    @_relationsOut = []
     @_include      = []
     @_select       = []
     @_noRelations  = true
@@ -106,7 +108,11 @@ class WeaverQuery
     @_addCondition(key, '$relIn', if node then node.id() else '*');
 
   hasRelationOut: (key, node) ->
-    @_addCondition(key, '$relOut', if node then node.id() else '*');
+    if _.isArray(key)
+      @_relationsOut = key # values are ignored
+    else
+      @_addCondition(key, '$relOut', if node then node.id() else '*');
+    @
 
   hasNoRelationIn: (key, node) ->
     @_addCondition(key, '$noRelIn', if node then node.id() else '*');

--- a/src/WeaverQuery.coffee
+++ b/src/WeaverQuery.coffee
@@ -104,8 +104,8 @@ class WeaverQuery
   greaterThanOrEqualTo: (key, value) ->
     @_addCondition(key, '$gte', value);
 
-  hasRelationIn: (key, node) ->
-    @_addCondition(key, '$relIn', if node then node.id() else '*');
+  hasRelationIn: (key, node...) ->
+    @_addCondition(key, '$relIn', if node.length > 0 then (i.id() for i in node) else ['*']);
 
   hasRelationOut: (key, node...) ->
     if _.isArray(key)
@@ -114,11 +114,11 @@ class WeaverQuery
       @_addCondition(key, '$relOut', if node.length > 0 then (i.id() for i in node) else ['*']);
     @
 
-  hasNoRelationIn: (key, node) ->
-    @_addCondition(key, '$noRelIn', if node then node.id() else '*');
+  hasNoRelationIn: (key, node...) ->
+    @_addCondition(key, '$noRelIn', if node.length > 0 then (i.id() for i in node) else ['*']);
 
-  hasNoRelationOut: (key, node) ->
-    @_addCondition(key, '$noRelOut', if node then node.id() else '*');
+  hasNoRelationOut: (key, node...) ->
+    @_addCondition(key, '$noRelOut', if node.length > 0 then (i.id() for i in node) else ['*']);
 
   containedIn: (key, values) ->
     @_addCondition(key, '$in', values);

--- a/src/WeaverQuery.coffee
+++ b/src/WeaverQuery.coffee
@@ -16,7 +16,6 @@ class WeaverQuery
     @_equals       = {}
     @_orQueries    = []
     @_conditions   = {}
-    @_relationsOut = []
     @_include      = []
     @_select       = []
     @_noRelations  = true
@@ -27,6 +26,7 @@ class WeaverQuery
     @_skip         = 0
     @_order        = []
     @_ascending    = true
+    @_arrayCount   = 0
 
   find: (Constructor) ->
 
@@ -105,14 +105,16 @@ class WeaverQuery
     @_addCondition(key, '$gte', value)
 
   hasRelationIn: (key, node...) ->
-    if node.length is 1 and node[0] instanceof WeaverQuery
+    if _.isArray(key)
+      @_addCondition("$relationArray${@arrayCount++}", '$relIn', key)
+    else if node.length is 1 and node[0] instanceof WeaverQuery
       @_addCondition(key, '$relIn', node)
     else
       @_addCondition(key, '$relIn', if node.length > 0 then (i.id() or i for i in node) else ['*'])
 
   hasRelationOut: (key, node...) ->
     if _.isArray(key)
-      @_relationsOut = key # values are ignored
+      @_addCondition("$relationArray${@arrayCount++}", '$relOut', key)
     else if node.length is 1 and node[0] instanceof WeaverQuery
       @_addCondition(key, '$relOut', node)
     else
@@ -120,13 +122,17 @@ class WeaverQuery
     @
 
   hasNoRelationIn: (key, node...) ->
-    if node.length is 1 and node[0] instanceof WeaverQuery
+    if _.isArray(key)
+      @_addCondition("$relationArray${@arrayCount++}", '$noRelIn', key)
+    else if node.length is 1 and node[0] instanceof WeaverQuery
       @_addCondition(key, '$noRelIn', node)
     else
       @_addCondition(key, '$noRelIn', if node.length > 0 then (i.id() or i for i in node) else ['*'])
 
   hasNoRelationOut: (key, node...) ->
-    if node.length is 1 and node[0] instanceof WeaverQuery
+    if _.isArray(key)
+      @_addCondition("$relationArray${@arrayCount++}", '$noRelOut', key)
+    else if node.length is 1 and node[0] instanceof WeaverQuery
       @_addCondition(key, '$noRelOut', node)
     else
       @_addCondition(key, '$noRelOut', if node.length > 0 then (i.id() or i for i in node) else ['*'])

--- a/src/WeaverQuery.coffee
+++ b/src/WeaverQuery.coffee
@@ -185,7 +185,7 @@ class WeaverQuery
     @_include = keys
     @
 
-  select: (keys) ->
+  select: (keys...) ->
     @_select = keys
     @
 

--- a/src/WeaverQuery.coffee
+++ b/src/WeaverQuery.coffee
@@ -107,11 +107,11 @@ class WeaverQuery
   hasRelationIn: (key, node) ->
     @_addCondition(key, '$relIn', if node then node.id() else '*');
 
-  hasRelationOut: (key, node) ->
+  hasRelationOut: (key, node...) ->
     if _.isArray(key)
       @_relationsOut = key # values are ignored
     else
-      @_addCondition(key, '$relOut', if node then node.id() else '*');
+      @_addCondition(key, '$relOut', if node.length > 0 then (i.id() for i in node) else ['*']);
     @
 
   hasNoRelationIn: (key, node) ->

--- a/test-server/docker-compose.yml
+++ b/test-server/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     - "5432"
 
   postgresql-connector:
-    image: sysunite/weaver-database-postgresql:0.0.14
+    image: sysunite/weaver-database-postgresql:0.0.15-SNAPSHOT-Q2
     links:
     - postgres
     expose:

--- a/test-server/docker-compose.yml
+++ b/test-server/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     - "5432"
 
   postgresql-connector:
-    image: sysunite/weaver-database-postgresql:0.0.15-SNAPSHOT-Q2-1
+    image: sysunite/weaver-database-postgresql:0.0.15-SNAPSHOT-Q2-2
     links:
     - postgres
     expose:

--- a/test-server/docker-compose.yml
+++ b/test-server/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     - "5432"
 
   postgresql-connector:
-    image: sysunite/weaver-database-postgresql:0.0.15-SNAPSHOT-Q2
+    image: sysunite/weaver-database-postgresql:0.0.15-SNAPSHOT-Q2-1
     links:
     - postgres
     expose:

--- a/test/WeaverQuery.test.coffee
+++ b/test/WeaverQuery.test.coffee
@@ -528,7 +528,7 @@ describe 'WeaverQuery Test', ->
       )
     )
 
-  it.skip 'should be able to do nested queries (to allow hops)', ->
+  it 'should be able to do nested queries (to allow hops)', ->
     a = new Weaver.Node('a')
     b = new Weaver.Node('b')
     c = new Weaver.Node('c')

--- a/test/WeaverQuery.test.coffee
+++ b/test/WeaverQuery.test.coffee
@@ -382,8 +382,21 @@ describe 'WeaverQuery Test', ->
       )
     )
 
+  it 'skips relation out value if an array is provided', ->
+    a = new Weaver.Node('a')
+    b = new Weaver.Node('b')
+    a.relation('linkA').add(b)
 
-  it.skip 'should allow "or" in predicates for hasRelationOut', ->
+    a.save().then(->
+      new Weaver.Query()
+      .hasRelationOut(['linkA'], 'c')
+      .find().then((nodes)->
+        expect(nodes.length).to.equal(1)
+        checkNodeInResult(nodes, 'a')
+      )
+    )
+
+  it 'should allow "or" in predicates for hasRelationOut', ->
     a = new Weaver.Node('a')
     b = new Weaver.Node('b')
     c = new Weaver.Node('c')

--- a/test/WeaverQuery.test.coffee
+++ b/test/WeaverQuery.test.coffee
@@ -328,6 +328,43 @@ describe 'WeaverQuery Test', ->
       )
     )
 
+  it 'should return all relations even on attribute selects', ->
+    a = new Weaver.Node('a')
+    b = new Weaver.Node('b')
+    a.set("name", "a name")
+    a.set("description", "a desc")
+    a.set("skip", "a skip")
+    a.relation('link').add(b)
+
+    a.save().then(->
+      new Weaver.Query()
+      .select('name', 'description')
+      .restrict(['a'])
+      .find().then((nodes)->
+        expect(nodes).to.have.length.be(1)
+        checkNodeInResult(nodes, 'a')
+        expect(nodes[0]).to.have.property('relations').to.have.property('link').to.have.length.be(1)
+    )
+
+  it 'should allow attribute selects', ->
+    a = new Weaver.Node('a')
+    a.set("name", "a name")
+    a.set("description", "a desc")
+    a.set("skip", "a skip")
+
+    a.save().then(->
+      new Weaver.Query()
+      .select('name', 'description')
+      .find().then((nodes)->
+        expect(nodes).to.have.length.be(1)
+        checkNodeInResult(nodes, 'a')
+        attrs = nodes[0].attributes
+        expect(attrs).to.have.property('name')
+        expect(attrs).to.have.property('description')
+        expect(attrs).to.not.have.property('skip')
+    )
+
+
   it 'should allow "or" in predicates for hasRelationOut', ->
     a = new Weaver.Node('a')
     b = new Weaver.Node('b')

--- a/test/WeaverQuery.test.coffee
+++ b/test/WeaverQuery.test.coffee
@@ -328,7 +328,7 @@ describe 'WeaverQuery Test', ->
       )
     )
 
-  it 'should return all relations even on attribute selects', ->
+  it.skip 'should return all relations even on attribute selects', ->
     a = new Weaver.Node('a')
     b = new Weaver.Node('b')
     a.set("name", "a name")
@@ -344,9 +344,10 @@ describe 'WeaverQuery Test', ->
         expect(nodes).to.have.length.be(1)
         checkNodeInResult(nodes, 'a')
         expect(nodes[0]).to.have.property('relations').to.have.property('link').to.have.length.be(1)
+      )
     )
 
-  it 'should allow attribute selects', ->
+  it.skip 'should allow attribute selects', ->
     a = new Weaver.Node('a')
     a.set("name", "a name")
     a.set("description", "a desc")
@@ -362,10 +363,11 @@ describe 'WeaverQuery Test', ->
         expect(attrs).to.have.property('name')
         expect(attrs).to.have.property('description')
         expect(attrs).to.not.have.property('skip')
+      )
     )
 
 
-  it 'should allow "or" in predicates for hasRelationOut', ->
+  it.skip 'should allow "or" in predicates for hasRelationOut', ->
     a = new Weaver.Node('a')
     b = new Weaver.Node('b')
     c = new Weaver.Node('c')
@@ -384,7 +386,7 @@ describe 'WeaverQuery Test', ->
       )
     )
 
-  it 'should allow "or" in objects for specific hasRelationOut', ->
+  it.skip 'should allow "or" in objects for specific hasRelationOut', ->
     a = new Weaver.Node('a')
     b = new Weaver.Node('b')
     c = new Weaver.Node('c')
@@ -403,7 +405,7 @@ describe 'WeaverQuery Test', ->
       )
     )
 
-  it 'should load in some secondary nodes with "selectOut"', ->
+  it.skip 'should load in some secondary nodes with "selectOut"', ->
     a = new Weaver.Node('a')
     b = new Weaver.Node('b')
     c = new Weaver.Node('c')
@@ -423,7 +425,7 @@ describe 'WeaverQuery Test', ->
       )
     )
 
-  it 'should ensure that nodes are not excluded based on the  "selectOut" flag', ->
+  it.skip 'should ensure that nodes are not excluded based on the  "selectOut" flag', ->
     a = new Weaver.Node('a')
     b = new Weaver.Node('b')
     c = new Weaver.Node('c')
@@ -444,7 +446,7 @@ describe 'WeaverQuery Test', ->
       )
     )
 
-  it 'should load in some secondary nodes with "selectIn"', ->
+  it.skip 'should load in some secondary nodes with "selectIn"', ->
     a = new Weaver.Node('a')
     b = new Weaver.Node('b')
     c = new Weaver.Node('c')
@@ -464,7 +466,7 @@ describe 'WeaverQuery Test', ->
       )
     )
 
-  it 'should ensure that nodes are not excluded based on the  "selectIn" flag', ->
+  it.skip 'should ensure that nodes are not excluded based on the  "selectIn" flag', ->
     a = new Weaver.Node('a')
     b = new Weaver.Node('b')
     c = new Weaver.Node('c')
@@ -484,7 +486,7 @@ describe 'WeaverQuery Test', ->
       )
     )
 
-  it 'should be able to do nested queries (to allow hops)', ->
+  it.skip 'should be able to do nested queries (to allow hops)', ->
     a = new Weaver.Node('a')
     b = new Weaver.Node('b')
     c = new Weaver.Node('c')
@@ -501,7 +503,7 @@ describe 'WeaverQuery Test', ->
       )
     )
 
-  it 'should also load secondary nodes in nested queries', ->
+  it.skip 'should also load secondary nodes in nested queries', ->
     a = new Weaver.Node('a')
     b = new Weaver.Node('b')
     c = new Weaver.Node('c')
@@ -518,7 +520,7 @@ describe 'WeaverQuery Test', ->
       )
     )
 
-  it 'should allow optional relations in queries', ->
+  it.skip 'should allow optional relations in queries', ->
     a = new Weaver.Node()
     b = new Weaver.Node()
 
@@ -534,7 +536,7 @@ describe 'WeaverQuery Test', ->
       )
     )
 
-  it 'should allow optional relations in nested queries', ->
+  it.skip 'should allow optional relations in nested queries', ->
     a1 = new Weaver.Node('a1')
     b1 = new Weaver.Node('b1')
     c1 = new Weaver.Node('c1')
@@ -573,7 +575,7 @@ describe 'WeaverQuery Test', ->
       )
     )
 
-  it 'should do a badass query', ->
+  it.skip 'should do a badass query', ->
     promises = []
 
     spaceType       = new Weaver.Node('SpaceType')

--- a/test/WeaverQuery.test.coffee
+++ b/test/WeaverQuery.test.coffee
@@ -415,7 +415,7 @@ describe 'WeaverQuery Test', ->
       )
     )
 
-  it.skip 'should allow "or" in objects for specific hasRelationOut', ->
+  it 'should allow "or" in objects for specific hasRelationOut', ->
     a = new Weaver.Node('a')
     b = new Weaver.Node('b')
     c = new Weaver.Node('c')

--- a/test/WeaverQuery.test.coffee
+++ b/test/WeaverQuery.test.coffee
@@ -327,3 +327,267 @@ describe 'WeaverQuery Test', ->
 
       )
     )
+
+  it 'should allow "or" in predicates for hasRelationOut', ->
+    a = new Weaver.Node('a')
+    b = new Weaver.Node('b')
+    c = new Weaver.Node('c')
+
+    a.relation('linkA').add(b)
+    b.relation('linkB').add(c)
+    c.relation('linkC').add(a)
+
+    a.save().then(->
+      new Weaver.Query()
+      .hasRelationOut(['linkA','linkB'])
+      .find().then((nodes)->
+        expect(nodes.length).to.equal(2)
+        checkNodeInResult(nodes, 'a')
+        checkNodeInResult(nodes, 'b')
+      )
+    )
+
+  it 'should allow "or" in objects for specific hasRelationOut', ->
+    a = new Weaver.Node('a')
+    b = new Weaver.Node('b')
+    c = new Weaver.Node('c')
+
+    a.relation('link').add(b)
+    b.relation('link').add(c)
+    c.relation('link').add(a)
+
+    a.save().then(->
+      new Weaver.Query()
+      .hasRelationOut('link',[ Weaver.Node.get('b'), Weaver.Node.get('c')])
+      .find().then((nodes)->
+        expect(nodes.length).to.equal(2)
+        checkNodeInResult(nodes, 'a')
+        checkNodeInResult(nodes, 'b')
+      )
+    )
+
+  it 'should load in some secondary nodes with "selectOut"', ->
+    a = new Weaver.Node('a')
+    b = new Weaver.Node('b')
+    c = new Weaver.Node('c')
+    a.relation('link').add(b)
+    a.relation('test').add(c)
+    c.set('name', 'bravo')
+
+    a.save().then(->
+      new Weaver.Query()
+      .hasRelationOut('link')
+      .selectOut('test') # selectOut is optional, it loads the attrs/rels for node c if node a has a 'test' relation to node c,
+                         # but does not exclude node a from the result set if node a does not have this relation
+      .find().then((nodes)->
+        expect(nodes.length).to.equal(1)
+        checkNodeInResult(nodes, 'a')
+        expect(nodes[0].relation('test').nodes[c].get('name')).to.equal('bravo')
+      )
+    )
+
+  it 'should ensure that nodes are not excluded based on the  "selectOut" flag', ->
+    a = new Weaver.Node('a')
+    b = new Weaver.Node('b')
+    c = new Weaver.Node('c')
+    d = new Weaver.Node('d')
+    a.relation('link').add(b)
+    b.relation('link').add(d)
+    a.relation('test').add(c)
+    c.set('name', 'bravo')
+
+    a.save().then(->
+      new Weaver.Query()
+      .hasRelationOut('link')
+      .selectOut('test')
+      .find().then((nodes)->
+        expect(nodes.length).to.equal(2)
+        checkNodeInResult(nodes, 'a')
+        checkNodeInResult(nodes, 'b')
+      )
+    )
+
+  it 'should load in some secondary nodes with "selectIn"', ->
+    a = new Weaver.Node('a')
+    b = new Weaver.Node('b')
+    c = new Weaver.Node('c')
+
+    a.relation('test').add(b)
+    b.relation('link').add(c)
+    a.set('name','alpha')
+
+    a.save().then(->
+      new Weaver.Query()
+      .hasRelationOut('link')
+      .selectIn('test')
+      .find().then((nodes)->
+        expect(nodes.length).to.equal(1)
+        checkNodeInResult(nodes, 'b')
+        expect(nodes[0].relationIn('test').nodes[a].get('name')).to.equal('alpha')
+      )
+    )
+
+  it 'should ensure that nodes are not excluded based on the  "selectIn" flag', ->
+    a = new Weaver.Node('a')
+    b = new Weaver.Node('b')
+    c = new Weaver.Node('c')
+    d = new Weaver.Node('d')
+    a.relation('test').add(b)
+    b.relation('link').add(c)
+    c.relation('link').add(d)
+
+    a.save().then(->
+      new Weaver.Query()
+      .hasRelationOut('link')
+      .selectIn('test')
+      .find().then((nodes)->
+        expect(nodes.length).to.equal(2)
+        checkNodeInResult(nodes, 'b')
+        checkNodeInResult(nodes, 'c')
+      )
+    )
+
+  it 'should be able to do nested queries (to allow hops)', ->
+    a = new Weaver.Node('a')
+    b = new Weaver.Node('b')
+    c = new Weaver.Node('c')
+    a.relation('link').add(b)
+    b.relation('link').add(c)
+
+    a.save().then(->
+      new Weaver.Query()
+      .hasRelationOut('link',
+        new Weaver.Query().hasRelationOut('link')
+      ).find().then((nodes)->
+        expect(nodes.length).to.equal(1)
+        checkNodeInResult(nodes, 'a')
+      )
+    )
+
+  it 'should also load secondary nodes in nested queries', ->
+    a = new Weaver.Node('a')
+    b = new Weaver.Node('b')
+    c = new Weaver.Node('c')
+    b.set('name', 'bravo')
+    a.relation('link').add(b)
+    b.relation('link').add(c)
+
+    a.save().then(->
+      new Weaver.Query()
+      .hasRelationOut('link',
+        new Weaver.Query().hasRelationOut('link')
+      ).find().then((nodes)->
+        expect(nodes[0].relation('link').nodes['b'].get('name')).to.equal('bravo')
+      )
+    )
+
+  it 'should allow optional relations in queries', ->
+    a = new Weaver.Node()
+    b = new Weaver.Node()
+
+    a.relation('link').add(b)
+
+    a.save().then(->
+      new Weaver.Query()
+      .hasOptionalRelationOut('link')
+      .find().then((nodes)->
+        expect(nodes.length).to.equal(2)
+        checkNodeInResult(nodes, 'a')
+        checkNodeInResult(nodes, 'b')
+      )
+    )
+
+  it 'should allow optional relations in nested queries', ->
+    a1 = new Weaver.Node('a1')
+    b1 = new Weaver.Node('b1')
+    c1 = new Weaver.Node('c1')
+    a2 = new Weaver.Node('a2')
+    b2 = new Weaver.Node('b2')
+    c2 = new Weaver.Node('c2')
+
+    x  = new Weaver.Node('x')
+
+    a1.relation('link').add(b1)
+    a1.relation('required').add(x)
+    b1.relation('valid').add(c1)
+    b1.set('name','bravo-one')
+
+    a2.relation('link').add(b2)
+    a2.relation('required').add(x)
+    b2.relation('invalid').add(c2)
+    b2.set('name','bravo-two')
+
+    Promise.all([a1.save(), a2.save()]).then(->
+
+      new Weaver.Query()
+      .hasRelationOut('required', Weaver.Node.get('x'))
+      .hasOptionalRelationOut('link',
+        new Weaver.Query().hasRelationOut('valid')
+      ).find().then((nodes)->
+        expect(nodes.length).to.equal(2)
+        checkNodeInResult(nodes, 'a1')
+        checkNodeInResult(nodes, 'a2')
+        # make sure the 'name' attribute for b1 is loaded, and not loaded for b2
+        for node in nodes
+          if node.id() is 'a1'
+            expect(node.relation('link').nodes['b1'].get('name')).to.equal('bravo-one')
+          if node.id() is 'a2'
+            expect(node.relation('link').nodes['b2'].get('name')).to.equal(undefined)
+      )
+    )
+
+  it 'should do a badass query', ->
+    promises = []
+
+    spaceType       = new Weaver.Node('SpaceType')
+    spaceGroupType  = new Weaver.Node('SpaceGroupType')
+    space1          = new Weaver.Node('space1')
+    space2          = new Weaver.Node('space2')
+    space3          = new Weaver.Node('space3')
+    connectionNode1 = new Weaver.Node('space1Conn')
+    connectionNode2 = new Weaver.Node('space2Conn')
+    spaceGroup1     = new Weaver.Node('spaceGroup1')
+    spaceGroup2     = new Weaver.Node('spaceGroup2')
+    spaceGroup3     = new Weaver.Node('spaceGroup3')
+    spaceReq1       = new Weaver.Node('spaceRequirement1')
+
+    space1.relation('type').add(spaceType)
+    space2.relation('type').add(spaceType)
+    space3.relation('type').add(spaceType)
+    spaceGroup1.relation('type').add(spaceGroupType)
+    spaceGroup2.relation('type').add(spaceGroupType)
+    spaceGroup3.relation('type').add(spaceGroupType)
+
+    spaceGroup1.relation('consistsOf').add(spaceGroup2)
+    spaceGroup2.relation('consistsOf').add(spaceGroup3)
+    spaceGroup3.relation('consistsOf').add(connectionNode1)
+    spaceGroup3.relation('consistsOf').add(connectionNode2)
+    connectionNode1.relation('to').add(space1)
+    connectionNode2.relation('to').add(space2)
+    space1.relation('hasSpaceRequirement').add(spaceReq1)
+    space2.relation('hasSpaceRequirement').add(spaceReq1)
+
+    spaceReq1.set('name','SpaceRequirementOne')
+
+    spaceGroup1.save().then(->
+      new Weaver.Query()
+      .hasRelationOut('type', [Weaver.Node.get('SpaceType'), Weaver.Node.get('SpaceGroupType')])
+      .selectOut(['hasSpaceRequirement', 'consistsOf'])
+      .selectIn(['consistsOf'])
+      .optionalRelationIn('to',
+        new Weaver.Query().hasRelationIn('consistsOf'),
+      ).optionalRelationOut('consistsOf',
+        new Weaver.Query().hasRelationOut('to')
+      ).find().then((nodes)->
+        expect(nodes.length).to.equal(6)
+        for node in nodes
+          switch(node.id())
+            when 'space1'
+              expect(node.relation('hasSpaceRequirement').nodes['spaceReq1'].get('name')).to.equal('SpaceRequirementOne')
+            when 'space2'
+              expect(node.relationIn('to').nodes['spaceConn2'].relationIn('consistsOf').nodes['spaceGroup3'])
+            when 'spaceGroup2'
+              expect(node.relationOut('consistsOf').nodes['spaceGroup3'].relationOut('consistsOf').nodes['spaceConn1'])
+      )
+    )
+

--- a/test/WeaverQuery.test.coffee
+++ b/test/WeaverQuery.test.coffee
@@ -243,6 +243,21 @@ describe 'WeaverQuery Test', ->
       )
     )
 
+  it 'should do relation hasNoRelationOut without relations', ->
+    a = new Weaver.Node("a")
+    b = new Weaver.Node("b")
+    c = new Weaver.Node("c")
+    a.relation("link").add(b)
+
+    Promise.all([a.save(), c.save()]).then(->
+      new Weaver.Query()
+      .hasNoRelationOut("link", b)
+      .find().then((nodes) ->
+        expect(nodes.length).to.equal(2)
+        checkNodeInResult(nodes, 'b')
+        checkNodeInResult(nodes, 'c')
+      )
+    )
 
   it 'should do relation hasNoRelationOut', ->
     a = new Weaver.Node("a")
@@ -251,7 +266,6 @@ describe 'WeaverQuery Test', ->
     a.relation("link").add(b)
 
     Promise.all([a.save(), c.save()]).then(->
-
       new Weaver.Query()
       .hasNoRelationOut("link", b)
       .withRelations()
@@ -261,7 +275,6 @@ describe 'WeaverQuery Test', ->
         checkNodeInResult(nodes, 'c')
       )
     )
-
 
   it 'should do relation hasNoRelationIn', ->
     a = new Weaver.Node("a")
@@ -426,7 +439,7 @@ describe 'WeaverQuery Test', ->
 
     a.save().then(->
       new Weaver.Query()
-      .hasRelationOut('link',[ Weaver.Node.get('b'), Weaver.Node.get('c')])
+      .hasRelationOut('link', Weaver.Node.get('b'), Weaver.Node.get('c'))
       .find().then((nodes)->
         expect(nodes.length).to.equal(2)
         checkNodeInResult(nodes, 'a')

--- a/test/WeaverQuery.test.coffee
+++ b/test/WeaverQuery.test.coffee
@@ -409,6 +409,61 @@ describe 'WeaverQuery Test', ->
       )
     )
 
+  it 'should allow "or" in predicates for hasNoRelationIn', ->
+    a = new Weaver.Node('a')
+    b = new Weaver.Node('b')
+    c = new Weaver.Node('c')
+
+    a.relation('linkA').add(b)
+    b.relation('linkB').add(c)
+    c.relation('linkC').add(a)
+
+    a.save().then(->
+      new Weaver.Query()
+      .hasNoRelationIn(['linkA','linkB'])
+      .find().then((nodes)->
+        expect(nodes.length).to.equal(1)
+        checkNodeInResult(nodes, 'a')
+      )
+    )
+
+  it 'should allow "or" in predicates for hasNoRelationOut', ->
+    a = new Weaver.Node('a')
+    b = new Weaver.Node('b')
+    c = new Weaver.Node('c')
+
+    a.relation('linkA').add(b)
+    b.relation('linkB').add(c)
+    c.relation('linkC').add(a)
+
+    a.save().then(->
+      new Weaver.Query()
+      .hasNoRelationOut(['linkA','linkB'])
+      .find().then((nodes)->
+        expect(nodes.length).to.equal(1)
+        checkNodeInResult(nodes, 'c')
+      )
+    )
+
+  it 'should allow "or" in predicates for hasRelationIn', ->
+    a = new Weaver.Node('a')
+    b = new Weaver.Node('b')
+    c = new Weaver.Node('c')
+
+    a.relation('linkA').add(b)
+    b.relation('linkB').add(c)
+    c.relation('linkC').add(a)
+
+    a.save().then(->
+      new Weaver.Query()
+      .hasRelationIn(['linkA','linkB'])
+      .find().then((nodes)->
+        expect(nodes.length).to.equal(2)
+        checkNodeInResult(nodes, 'b')
+        checkNodeInResult(nodes, 'c')
+      )
+    )
+
   it 'should allow "or" in predicates for hasRelationOut', ->
     a = new Weaver.Node('a')
     b = new Weaver.Node('b')


### PR DESCRIPTION
New query functionality for nested relation queries and multiple option relation queries.

e.g. 
```
new Weaver.Query().hasNoRelationIn(['a','b'])
new Weaver.Query().hasNoRelationIn('a',['b', 'c'])
new Weaver.Query().hasRelationOut('a',new Weaver.Query().hasRelationOut('b))
```