### PR TITLE
Nested load is fixed in the postgres-connector used

### DIFF
--- a/test-server/docker-compose.yml
+++ b/test-server/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     - "5432"
 
   postgresql-connector:
-    image: sysunite/weaver-database-postgresql:0.0.15
+    image: sysunite/weaver-database-postgresql:0.0.16-SNAPSHOT-nested-load
     links:
     - postgres
     expose:

--- a/test/WeaverQuery.test.coffee
+++ b/test/WeaverQuery.test.coffee
@@ -600,7 +600,7 @@ describe 'WeaverQuery Test', ->
       )
     )
 
-  it.skip 'should also load secondary nodes in nested queries', ->
+  it 'should also load secondary nodes in nested queries', ->
     a = new Weaver.Node('a')
     b = new Weaver.Node('b')
     c = new Weaver.Node('c')


### PR DESCRIPTION
This test now passes because of https://github.com/weaverplatform/weaver-database-postgresql/pull/31