### PR TITLE
Select out

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "mohamad@sysunite.com"
   },
   "com_weaverplatform": {
-    "requiredServerVersion": "~3.0.6"
+    "requiredServerVersion": "~3.0.7 || ^3.0.7-beta.0"
   },
   "main": "lib/Weaver.js",
   "license": "GPL-3.0",

--- a/src/WeaverNode.coffee
+++ b/src/WeaverNode.coffee
@@ -35,7 +35,7 @@ class WeaverNode
       for relation in relations
         instance = new Constructor(relation.target.nodeId)
         instance._loadFromQuery(relation.target, Constructor)
-        @relation(key).add(instance, relation.nodeId)
+        @relation(key).add(instance, relation.nodeId, false)
 
     @._clearPendingWrites()
     @

--- a/src/WeaverQuery.coffee
+++ b/src/WeaverQuery.coffee
@@ -20,6 +20,7 @@ class WeaverQuery
     @_conditions   = {}
     @_include      = []
     @_select       = []
+    @_selectOut    = []
     @_noRelations  = true
     @_noAttributes = true
     @_count        = false
@@ -227,6 +228,10 @@ class WeaverQuery
 
   select: (keys...) ->
     @_select = keys
+    @
+
+  selectOut: (relationKeys...) ->
+    @_selectOut = relationKeys
     @
 
   hollow: (value) ->

--- a/src/WeaverQuery.coffee
+++ b/src/WeaverQuery.coffee
@@ -231,7 +231,7 @@ class WeaverQuery
     @
 
   selectOut: (relationKeys...) ->
-    @_selectOut = relationKeys
+    @_selectOut.push(relationKeys)
     @
 
   hollow: (value) ->

--- a/src/WeaverRelation.coffee
+++ b/src/WeaverRelation.coffee
@@ -30,7 +30,7 @@ class WeaverRelation
   first: ->
     @.all()[0]
 
-  add: (node, relId) ->
+  add: (node, relId, addToPendingWrites = true) ->
     relId = cuid() if not relId?
     @nodes[node.id()] = node
 

--- a/test-server/docker-compose.yml
+++ b/test-server/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     command: server /data
 
   weaver-server:
-    image: sysunite/weaver-server:3.0.6
+    image: sysunite/weaver-server:3.0.7-beta.0
     expose:
     - "9487"
     ports:

--- a/test-server/docker-compose.yml
+++ b/test-server/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     - "5432"
 
   postgresql-connector:
-    image: sysunite/weaver-database-postgresql:0.0.16-SNAPSHOT-nested-load
+    image: sysunite/weaver-database-postgresql:0.0.16-SNAPSHOT-select-out
     links:
     - postgres
     expose:

--- a/test/WeaverQuery.test.coffee
+++ b/test/WeaverQuery.test.coffee
@@ -529,7 +529,7 @@ describe 'WeaverQuery Test', ->
       .find().then((nodes)->
         expect(nodes.length).to.equal(1)
         checkNodeInResult(nodes, 'a')
-        expect(nodes[0].relation('test').nodes[c].get('name')).to.equal('bravo')
+        expect(nodes[0].relation('test').nodes['c'].get('name')).to.equal('bravo')
       )
     )
 

--- a/test/WeaverQuery.test.coffee
+++ b/test/WeaverQuery.test.coffee
@@ -533,6 +533,27 @@ describe 'WeaverQuery Test', ->
       )
     )
 
+  it 'should support multiple hops for selectOut', ->
+    a = new Weaver.Node('a')
+    b = new Weaver.Node('b')
+    c = new Weaver.Node('c')
+    a.relation('link').add(b)
+    b.relation('test').add(c)
+    c.set('name', 'grazitutti')
+
+    a.save().then(->
+      new Weaver.Query()
+      .hasRelationOut('link')
+      .selectOut('link', 'test')
+      .find().then((nodes)->
+        expect(nodes.length).to.equal(1)
+        checkNodeInResult(nodes, 'a')
+        loadedB = nodes[0].relation('link').nodes['b']
+        expect(loadedB).to.exist
+        expect(loadedB.relation('test').nodes['c'].get('name')).to.equal('grazitutti')
+      )
+    )
+
   it 'should not allow multiple selectOut clauses (yet)', ->
     new Weaver.Query()
     .selectOut('test')

--- a/test/WeaverQuery.test.coffee
+++ b/test/WeaverQuery.test.coffee
@@ -533,6 +533,12 @@ describe 'WeaverQuery Test', ->
       )
     )
 
+  it 'should not allow multiple selectOut clauses (yet)', ->
+    new Weaver.Query()
+    .selectOut('test')
+    .selectOut('another')
+    .find().should.be.rejected
+
   it 'should ensure that nodes are not excluded based on the  "selectOut" flag', ->
     a = new Weaver.Node('a')
     b = new Weaver.Node('b')

--- a/test/WeaverQuery.test.coffee
+++ b/test/WeaverQuery.test.coffee
@@ -502,7 +502,7 @@ describe 'WeaverQuery Test', ->
       )
     )
 
-  it.skip 'should load in some secondary nodes with "selectOut"', ->
+  it 'should load in some secondary nodes with "selectOut"', ->
     a = new Weaver.Node('a')
     b = new Weaver.Node('b')
     c = new Weaver.Node('c')
@@ -522,7 +522,7 @@ describe 'WeaverQuery Test', ->
       )
     )
 
-  it.skip 'should ensure that nodes are not excluded based on the  "selectOut" flag', ->
+  it 'should ensure that nodes are not excluded based on the  "selectOut" flag', ->
     a = new Weaver.Node('a')
     b = new Weaver.Node('b')
     c = new Weaver.Node('c')


### PR DESCRIPTION
Select out allows nested nodes to be loaded based on preselected relations.

Note:
```
a -x> b
a -x> c
c -x> b
```
with selectOut(x,x) results in two different WeaverNode instances with id b for now.