### PR TITLE
Concurrent save

### DIFF
--- a/src/Weaver.coffee
+++ b/src/Weaver.coffee
@@ -2,7 +2,7 @@ Promise = require('bluebird')
 
 class Weaver
 
-  constructor: ->
+  constructor: (opts)->
 
     if Weaver.instance?
       throw new Error('Do not instantiate Weaver twice')
@@ -30,6 +30,9 @@ class Weaver
     @coreManager = new Weaver.CoreManager()
     @_connected  = false
     @_local      = false
+
+    if opts?
+      @setOptions(opts)
 
   version: ->
     require('../package.json').version
@@ -85,6 +88,10 @@ class Weaver
   # on the promise library for the digestion cycle to work.
   setScheduler: (fn) ->
     Promise.setScheduler(fn)
+
+  setOptions: (opts)->
+    if opts?ignoresOutOfDate
+      @_ignoresOutOfDate = opts.ignoresOutOfDate
 
   # Returns the Weaver instance if instantiated. This should be called from
   # a static reference

--- a/src/WeaverNode.coffee
+++ b/src/WeaverNode.coffee
@@ -239,7 +239,7 @@ class WeaverNode
 
 
   # Save node and all values / relations and relation objects to server
-  save: (project, opts) ->
+  save: (project) ->
     cm = Weaver.getCoreManager()
 
     sp = cm.operationsQueue.then(=>
@@ -269,26 +269,6 @@ class WeaverNode
           resultReject(e)
         )
       )
-    ).catch((err)=>
-      # out-of-date attribute workaround
-      ids = []
-      if opts.ignoresOutOfDate and err.message.indexOf('ERROR: duplicate key value violates unique constraint "replaced_attributes_replaced_key"') isnt -1
-        stringTerminatedIds = err.toString().match(/'(.)+'\)/g) # get the id's we need from the error message
-        ids = stringTerminatedIds.map((id)-> id.slice(1,-2))
-
-        for write in @pendingWrites # get the 'key' for the offending attribute
-          key = write.key if write.id = ids[2]
-
-        Weaver.Node.load(@id()).then((res)=>
-          updatedAttrId = res.attributes[key][0].nodeId
-          for write in @pendingWrites
-            if write.id is ids[2] and write.replacesId is ids[1] and write.replaceId is ids[0]
-              write.replacesId = updatedAttrId # replace the out-of-date id with the server-loaded id
-
-          @save(project,{ignoresOutOfDate: true})
-        )
-      else
-        throw err
     )
 
 

--- a/test/WeaverNode.test.coffee
+++ b/test/WeaverNode.test.coffee
@@ -357,13 +357,13 @@ describe 'WeaverNode test', ->
     )
 
   it 'should handle concurrent saves from multiple references, when the flag is passed', ->
-
+    weaver.setOptions({ignoresOutOfDate: true})
     a = new Weaver.Node('a') # a node is created and saved at some point
     a.set('name','a')
     ay = {}
     aay = {}
 
-    a.save(null,{ignoresOutOfDate:true}).then(->  # :: USE CASE ::
+    a.save().then(->  # :: USE CASE ::
       Weaver.Node.load('a')                       # node is loaded and assigned to some view variable at some point
     ).then((res)->
       ay = res
@@ -371,28 +371,23 @@ describe 'WeaverNode test', ->
     ).then((res)->
       aay = res
       ay.set('name','Ay')                         # user changed the name to 'Ay'
-      ay.save(null,{ignoresOutOfDate : true})
+      ay.save()
       aay.set('name','A')                         # at some point in the future, a user saw the result, recognized the typo, and decided to change the name back to 'A'
-      aay.save(null,{ignoresOutOfDate: true})     # (it's weird that he would do this in a separate component, but hey, monkey-testing)
+      aay.save()     # (it's weird that he would do this in a separate component, but hey, monkey-testing)
     ).then((res)->
       res.set('name','_A')
-      res.save(null,{ignoresOutOfDate: true})
+      res.save()
     ).then(()->
       Weaver.Node.load('a')
     ).then((res)->
       assert.equal(res.get('name'),'_A')
       res.set('name','A_')
-      res.save(null,{ignoresOutOfDate: true})
+      res.save()
     ).then((res)->
       assert.equal(res.get('name'),'A_')
     ).then(->
       ay.set('name', 'Ay')
-      ay.save(null,{ignoresOutOfDate: true})
+      ay.save()
       aay.set('name','Aay')
-      aay.save(null,{ignoresOutOfDate: true})
-    ).catch((err)->
-      console.log(err)
-      assert.equal('money','happiness')
+      aay.save()
     )
-
-

--- a/test/WeaverNode.test.coffee
+++ b/test/WeaverNode.test.coffee
@@ -355,3 +355,28 @@ describe 'WeaverNode test', ->
     ).then((node) ->
       assert.isDefined(node.relation('to').nodes[cloned.id()])
     )
+
+  it 'should reject interaction with out-of-date nodes (out-of-date node attributes, specifically)', ->
+
+    a = new Weaver.Node('a') # a node is created and saved at some point
+    a.set('name','a')
+    ay = {}
+    aay = {}
+
+    a.save().then(->
+      Weaver.Node.load('a') # node is loaded and assigned to some view variable at some point
+    ).then((res)->
+      ay = res
+      Weaver.Node.load('a') # node is loaded and assigned to some other view variable at some point (inside a separate component, most likely)
+    ).then((res)->
+      aay = res
+      ay.set('name','Aq') # user changed the name to 'Aq'
+      ay.save()
+      aay.set('name','A') # at some point in the future, a user saw the result, recognized the typo, and decided to change the name back to 'A'
+                          # (it's weird that he would do this in a separate component, but hey, monkey-testing)
+      aay.save()
+    ).catch((err)->
+      expect(err).to.be.defined
+    )
+
+


### PR DESCRIPTION
Allows ignoring of out-of-date attributes updates during `Weaver.Node.save()` operations, as a workaround until a better system of concurrent interaction is devised.