### PR TITLE
Improve test speed

### DIFF
--- a/src/WeaverNode.coffee
+++ b/src/WeaverNode.coffee
@@ -21,11 +21,14 @@ class WeaverNode
 
   # Node loading from server
   @load: (nodeId, target, Constructor, includeRelations = false, includeAttributes = false) ->
-    Constructor = WeaverNode if not Constructor?
-    query = new Weaver.Query(target)
-    query.withRelations() if includeRelations
-    query.withAttributes() if includeAttributes
-    query.get(nodeId, Constructor)
+    if !nodeId?
+      Promise.reject("Cannot load nodes with an undefined id")
+    else
+      Constructor = WeaverNode if not Constructor?
+      query = new Weaver.Query(target)
+      query.withRelations() if includeRelations
+      query.withAttributes() if includeAttributes
+      query.get(nodeId, Constructor)
 
 
   @loadFromQuery: (node, constructorFunction) ->

--- a/test/Application.test.coffee
+++ b/test/Application.test.coffee
@@ -1,4 +1,4 @@
-weaver = require("./test-suite")
+weaver = require("./test-suite").weaver
 
 
 describe 'Application test', ->

--- a/test/Authorization.test.coffee
+++ b/test/Authorization.test.coffee
@@ -1,11 +1,11 @@
-weaver = require("./test-suite")
+weaver = require("./test-suite").weaver
+wipeCurrentProject = require("./test-suite").wipeCurrentProject
 Weaver = require('../src/Weaver')
 Promise = require('bluebird')
 
 describe 'Authorization test', ->
   beforeEach ->
     wipeCurrentProject()
-
 
   it 'should not allow project creation by default', ->
     testUser = new Weaver.User('testuser', 'testpassword', 'email@dontevenvalidate.com')

--- a/test/Authorization.test.coffee
+++ b/test/Authorization.test.coffee
@@ -3,6 +3,8 @@ Weaver = require('../src/Weaver')
 Promise = require('bluebird')
 
 describe 'Authorization test', ->
+  beforeEach ->
+    wipeCurrentProject()
 
 
   it 'should not allow project creation by default', ->

--- a/test/Integration.test.coffee
+++ b/test/Integration.test.coffee
@@ -6,6 +6,8 @@ alphaProject = null
 betaProject  = null
 
 describe 'Integration Test', ->
+  beforeEach ->
+    wipeCurrentProject()
 
   it 'should demonstrate and assess all Weaver functionality', ->
 
@@ -23,7 +25,7 @@ describe 'Integration Test', ->
       # - no data in any database
       # We therefore call the wipe function that only works in Development mode
       weaver.wipe()
-    
+
     ).then(->
 
       # Create a project with a name

--- a/test/Integration.test.coffee
+++ b/test/Integration.test.coffee
@@ -1,14 +1,11 @@
 Promise = require('bluebird')
-weaver = require("./test-suite")
+weaver = require("./test-suite").weaver
 Weaver = require('../src/Weaver')
 
 alphaProject = null
 betaProject  = null
 
 describe 'Integration Test', ->
-  beforeEach ->
-    wipeCurrentProject()
-
   it 'should demonstrate and assess all Weaver functionality', ->
 
     # Map to save state between promises

--- a/test/WeaverACL.test.coffee
+++ b/test/WeaverACL.test.coffee
@@ -1,11 +1,8 @@
-weaver = require("./test-suite")
+weaver = require("./test-suite").weaver
 Weaver = require('../src/Weaver')
 Promise = require('bluebird')
 
 describe 'WeaverACL test', ->
-  beforeEach ->
-    wipeCurrentProject()
-
   it 'should create a new ACL', ->
     acl = new Weaver.ACL()
     acl.save().then((acl) ->

--- a/test/WeaverACL.test.coffee
+++ b/test/WeaverACL.test.coffee
@@ -3,6 +3,8 @@ Weaver = require('../src/Weaver')
 Promise = require('bluebird')
 
 describe 'WeaverACL test', ->
+  beforeEach ->
+    wipeCurrentProject()
 
   it 'should create a new ACL', ->
     acl = new Weaver.ACL()

--- a/test/WeaverFile.test.coffee
+++ b/test/WeaverFile.test.coffee
@@ -1,4 +1,5 @@
-weaver = require("./test-suite")
+weaver = require("./test-suite").weaver
+wipeCurrentProject = require("./test-suite").wipeCurrentProject
 Weaver = require('../src/Weaver')
 
 path     = require('path')

--- a/test/WeaverFile.test.coffee
+++ b/test/WeaverFile.test.coffee
@@ -6,6 +6,9 @@ Promise  = require('bluebird')
 readFile = Promise.promisify(require('fs').readFile)
 
 describe 'WeaverFile test', ->
+  beforeEach ->
+    wipeCurrentProject()
+
   file = ''
   tmpDir = path.join(__dirname,"../tmp")
 
@@ -188,7 +191,7 @@ describe 'WeaverFile test', ->
     it 'should allow users with read permission access to attachments', ->
       weaver.signOut().then(-> weaver.signInWithUsername('readonly', 'password'))
       .then(-> new Weaver.File().getFileByID('./tmp/test-file', @fileId))
-    
+
     it 'should not allow users without read permission access to attachments', ->
       weaver.signOut().then(-> weaver.signInWithUsername('noAccess', 'password'))
       .then(->

--- a/test/WeaverHistory.test.coffee
+++ b/test/WeaverHistory.test.coffee
@@ -1,4 +1,5 @@
-weaver  = require("./test-suite")
+weaver  = require("./test-suite").weaver
+wipeCurrentProject  = require("./test-suite").wipeCurrentProject
 Weaver  = require('../src/Weaver')
 Promise = require('bluebird')
 

--- a/test/WeaverHistory.test.coffee
+++ b/test/WeaverHistory.test.coffee
@@ -3,6 +3,9 @@ Weaver  = require('../src/Weaver')
 Promise = require('bluebird')
 
 describe 'WeaverHistory test', ->
+  beforeEach ->
+    wipeCurrentProject()
+
   it 'should set a new string attribute', ->
     node = new Weaver.Node()
     nodeB = new Weaver.Node()

--- a/test/WeaverNode.test.coffee
+++ b/test/WeaverNode.test.coffee
@@ -11,7 +11,9 @@ describe 'WeaverNode test', ->
     )
 
   it 'should reject loading undefined nodes', ->
-    Weaver.Node.load(undefined).should.eventually.be.rejected
+    new Weaver.Node().save().then( ->
+      Weaver.Node.load(undefined).should.eventually.be.rejected
+    )
 
   it 'should reject loading unexistant nodes', ->
     Weaver.Node.load('doesnt-exist').should.eventually.be.rejected

--- a/test/WeaverNode.test.coffee
+++ b/test/WeaverNode.test.coffee
@@ -2,6 +2,8 @@ weaver = require("./test-suite")
 Weaver = require('../src/Weaver')
 
 describe 'WeaverNode test', ->
+  beforeEach ->
+    wipeCurrentProject()
 
   it 'should handle concurrent remove node operations', ->
     a = new Weaver.Node()
@@ -322,7 +324,7 @@ describe 'WeaverNode test', ->
     paper = new Weaver.Node('paper')
     sissors = new Weaver.Node('sissors')
     rock = new Weaver.Node('rock')
-    
+
     player = new Weaver.Node('player')
 
     paper.relation('beats').add(rock)

--- a/test/WeaverNode.test.coffee
+++ b/test/WeaverNode.test.coffee
@@ -76,11 +76,12 @@ describe 'WeaverNode test', ->
 
   it 'should remove a node', ->
     node = new Weaver.Node()
+    id = node.id()
 
     node.save().then((node) ->
       node.destroy()
     ).then(->
-      Weaver.Node.load(node.id())
+      Weaver.Node.load(id)
     ).catch((error) ->
       assert.equal(error.code, Weaver.Error.NODE_NOT_FOUND)
     )

--- a/test/WeaverNode.test.coffee
+++ b/test/WeaverNode.test.coffee
@@ -1,10 +1,8 @@
-weaver = require("./test-suite")
+weaver = require("./test-suite").weaver
+wipeCurrentProject = require("./test-suite").wipeCurrentProject
 Weaver = require('../src/Weaver')
 
 describe 'WeaverNode test', ->
-  beforeEach ->
-    wipeCurrentProject()
-
   it 'should handle concurrent remove node operations', ->
     a = new Weaver.Node()
 
@@ -31,26 +29,26 @@ describe 'WeaverNode test', ->
       assert.isUndefined(res.relations.link)
     )
 
-
   it 'should propagate delete to relations (part 2)', ->
     a = new Weaver.Node()
     b = new Weaver.Node()
     c = new Weaver.Node()
 
-    a.relation('link').add(b)
-    c.relation('link').add(c)
-    Promise.all([a.save(), c.save()]).then(->
+    a.relation('2link').add(b)
+    c.relation('2link').add(c)
+    wipeCurrentProject().then(->
+      Promise.all([a.save(), c.save()])
+    ).then(->
       b.destroy()
     ).then(->
       new Weaver.Query()
       .withRelations()
-      .hasNoRelationIn('link')
-      .hasNoRelationOut('link')
+      .hasNoRelationIn('2link')
+      .hasNoRelationOut('2link')
       .find()
     ).then((res)->
       assert.equal(res.length, 2)
     )
-
 
   it 'should create a new node', ->
     node = new Weaver.Node()
@@ -201,8 +199,8 @@ describe 'WeaverNode test', ->
     )
 
   it.skip 'should give an error if node already exists', ->
-    node1 = new Weaver.Node('a')
-    node2 = new Weaver.Node('a')
+    node1 = new Weaver.Node('double-node')
+    node2 = new Weaver.Node('double-node')
 
     node1.save().then(->
       node2.save()
@@ -265,9 +263,9 @@ describe 'WeaverNode test', ->
     )
 
   it 'should clone a node', ->
-    a = new Weaver.Node('a')
-    b = new Weaver.Node('b')
-    c = new Weaver.Node('c')
+    a = new Weaver.Node('clonea')
+    b = new Weaver.Node('cloneb')
+    c = new Weaver.Node('clonec')
     cloned = null
 
     a.set('name', 'Foo')
@@ -278,11 +276,12 @@ describe 'WeaverNode test', ->
     b.relation('to').add(c)
     c.relation('to').add(a)
 
-    Weaver.Node.batchSave([a,b,c])
-    .then(->
-      a.clone('new-a')
+    wipeCurrentProject().then(->
+      Weaver.Node.batchSave([a,b,c])
+    ).then(->
+      a.clone('cloned-a')
     ).then( ->
-      Weaver.Node.load('new-a')
+      Weaver.Node.load('cloned-a')
     ).then((cloned) ->
       assert.notEqual(cloned.id(), a.id())
       assert.equal(cloned.get('name'), 'Foo')
@@ -290,7 +289,7 @@ describe 'WeaverNode test', ->
       assert.equal(to.id(), b.id())
       Weaver.Node.load(c.id())
     ).then((node) ->
-      assert.isDefined(node.relation('to').nodes['new-a'])
+      assert.isDefined(node.relation('to').nodes['cloned-a'])
     )
 
   it 'should recursively clone a node', ->
@@ -321,11 +320,11 @@ describe 'WeaverNode test', ->
     )
 
   it 'should clone links to loops', ->
-    paper = new Weaver.Node('paper')
-    sissors = new Weaver.Node('sissors')
-    rock = new Weaver.Node('rock')
+    paper = new Weaver.Node('2paper')
+    sissors = new Weaver.Node('2sissors')
+    rock = new Weaver.Node('2rock')
 
-    player = new Weaver.Node('player')
+    player = new Weaver.Node('2player')
 
     paper.relation('beats').add(rock)
     rock.relation('beats').add(sissors)
@@ -333,12 +332,12 @@ describe 'WeaverNode test', ->
     player.relation('chooses').add(sissors)
 
     player.save().then(->
-      paper.clone('new-paper', 'beats')
+      paper.clone('2new-paper', 'beats')
     ).then(->
-      Weaver.Node.load('player')
+      Weaver.Node.load('2player')
     ).then((pl) ->
       expect(pl.relation('chooses').all()).to.have.length.be(2)
-      expect(pl.relation('chooses').nodes).to.have.property('sissors')
+      expect(pl.relation('chooses').nodes).to.have.property('2sissors')
     )
 
   it 'should load an incomplete node', ->
@@ -356,21 +355,21 @@ describe 'WeaverNode test', ->
     )
 
   it 'should create and return a node if it doesn\'t exist', ->
-    Weaver.Node.firstOrCreate('test')
+    Weaver.Node.firstOrCreate('firstOrCreate')
       .then((node) ->
         assert.isTrue(node._stored)
-        assert.equal(node.id(), 'test')
+        assert.equal(node.id(), 'firstOrCreate')
       )
 
   it 'should not create a node return the existing node if it already exist', ->
-    new Weaver.Node('test').save()
+    new Weaver.Node('firstOrCreateExists').save()
       .then((node) ->
         assert.isTrue(node._stored)
-        Weaver.Node.firstOrCreate('test')
+        Weaver.Node.firstOrCreate('firstOrCreateExists')
       ).then((node) ->
         assert.isTrue(node._stored)
         assert.isTrue(node._loaded)
-        assert.equal(node.id(), 'test')
+        assert.equal(node.id(), 'firstOrCreateExists')
       )
 
   it 'should be possible to get write operations from a node when weaver is not instantiated', ->
@@ -378,7 +377,7 @@ describe 'WeaverNode test', ->
     Weaver.instance = undefined
     try
 
-      node = new Weaver.Node('test')
+      node = new Weaver.Node('jim')
       node.set('has', 'beans')
 
       operations = node.peekPendingWrites()

--- a/test/WeaverPlugin.test.coffee
+++ b/test/WeaverPlugin.test.coffee
@@ -2,7 +2,6 @@ weaver = require("./test-suite")
 Weaver = require('../src/Weaver')
 
 describe 'WeaverPlugin test', ->
-
   it 'should list available plugins', ->
     Weaver.Plugin.list().then((plugins) ->
       expect(plugins).to.have.length.be.at.least(2)

--- a/test/WeaverPlugin.test.coffee
+++ b/test/WeaverPlugin.test.coffee
@@ -1,4 +1,4 @@
-weaver = require("./test-suite")
+weaver = require("./test-suite").weaver
 Weaver = require('../src/Weaver')
 
 describe 'WeaverPlugin test', ->

--- a/test/WeaverProject.test.coffee
+++ b/test/WeaverProject.test.coffee
@@ -3,6 +3,9 @@ Weaver  = require('../src/Weaver')
 Promise = require('bluebird')
 
 describe 'WeaverProject Test', ->
+  beforeEach ->
+    wipeCurrentProject()
+
   actualProject = (p) ->
     expect(p).to.have.property('_stored').to.be.a('boolean').to.equal(true)
     expect(p).to.have.property('destroy').be.a('function')
@@ -179,7 +182,7 @@ describe 'WeaverProject Test', ->
 
   it 'should snapshot a project and get a minio filename gz', ->
     p = weaver.currentProject()
-    
+
     a = new Weaver.Node()
     b = new Weaver.Node()
     c = new Weaver.Node()

--- a/test/WeaverProject.test.coffee
+++ b/test/WeaverProject.test.coffee
@@ -1,4 +1,5 @@
-weaver  = require("./test-suite")
+weaver  = require("./test-suite").weaver
+wipeCurrentProject = require("./test-suite").wipeCurrentProject
 Weaver  = require('../src/Weaver')
 Promise = require('bluebird')
 

--- a/test/WeaverQuery.test.coffee
+++ b/test/WeaverQuery.test.coffee
@@ -3,13 +3,12 @@ wipeCurrentProject = require("./test-suite").wipeCurrentProject
 Weaver = require('../src/Weaver')
 
 checkNodeInResult = (nodes, nodeId) ->
-  beforeEach ->
-    wipeCurrentProject()
-
   ids = (i.id() for i in nodes)
   expect(ids).to.contain(nodeId)
 
 describe 'WeaverQuery Test', ->
+  beforeEach ->
+    wipeCurrentProject()
 
   it 'should restrict to a single node', ->
     a = new Weaver.Node("a")

--- a/test/WeaverQuery.test.coffee
+++ b/test/WeaverQuery.test.coffee
@@ -1,4 +1,5 @@
-weaver = require("./test-suite")
+weaver = require("./test-suite").weaver
+wipeCurrentProject = require("./test-suite").wipeCurrentProject
 Weaver = require('../src/Weaver')
 
 checkNodeInResult = (nodes, nodeId) ->

--- a/test/WeaverQuery.test.coffee
+++ b/test/WeaverQuery.test.coffee
@@ -2,6 +2,9 @@ weaver = require("./test-suite")
 Weaver = require('../src/Weaver')
 
 checkNodeInResult = (nodes, nodeId) ->
+  beforeEach ->
+    wipeCurrentProject()
+
   ids = (i.id() for i in nodes)
   expect(ids).to.contain(nodeId)
 
@@ -708,7 +711,7 @@ describe 'WeaverQuery Test', ->
       expect(nodes.length).to.equal(1)
       expect(nodes[0].relation('rec').nodes['b'].relation('rec').nodes['c'].relation('rec').nodes['d'].relation('rec').nodes['e'].get('name')).to.equal("toprec")
     )
-  
+
   it 'shoud support multiple recursive selectOut relations', ->
     a = new Weaver.Node('a')
     b = new Weaver.Node('b')

--- a/test/WeaverRESAPI.test.coffee
+++ b/test/WeaverRESAPI.test.coffee
@@ -1,4 +1,5 @@
-weaver  = require("./test-suite")
+weaver  = require("./test-suite").weaver
+wipeCurrentProject = require("./test-suite").wipeCurrentProject
 cuid    = require('cuid')
 Weaver  = require('../src/Weaver')
 Promise = require('bluebird')

--- a/test/WeaverRESAPI.test.coffee
+++ b/test/WeaverRESAPI.test.coffee
@@ -8,6 +8,8 @@ supertest = require('supertest')
 weaverServer = supertest.agent(WEAVER_ENDPOINT)
 
 describe 'Weaver Tests dealing with REST API', ->
+  beforeEach ->
+    wipeCurrentProject()
 
   it 'should retrieve the list of users providing the authtoken on query param', ->
     Promise.map([

--- a/test/WeaverRelation.test.coffee
+++ b/test/WeaverRelation.test.coffee
@@ -2,6 +2,8 @@ weaver = require("./test-suite")
 Weaver = require('../src/Weaver')
 
 describe 'Weaver relation and WeaverRelationNode test', ->
+  beforeEach ->
+    wipeCurrentProject()
 
   it 'should add a new relation without id', ->
     foo = new Weaver.Node()

--- a/test/WeaverRelation.test.coffee
+++ b/test/WeaverRelation.test.coffee
@@ -1,10 +1,7 @@
-weaver = require("./test-suite")
+weaver = require("./test-suite").weaver
 Weaver = require('../src/Weaver')
 
 describe 'Weaver relation and WeaverRelationNode test', ->
-  beforeEach ->
-    wipeCurrentProject()
-
   it 'should add a new relation without id', ->
     foo = new Weaver.Node()
     bar = new Weaver.Node()

--- a/test/WeaverUser.test.coffee
+++ b/test/WeaverUser.test.coffee
@@ -1,4 +1,5 @@
-weaver  = require("./test-suite")
+weaver  = require("./test-suite").weaver
+wipeCurrentProject = require("./test-suite").wipeCurrentProject
 cuid    = require('cuid')
 Weaver  = require('../src/Weaver')
 Promise = require('bluebird')

--- a/test/WeaverUser.test.coffee
+++ b/test/WeaverUser.test.coffee
@@ -4,6 +4,9 @@ Weaver  = require('../src/Weaver')
 Promise = require('bluebird')
 
 describe 'WeaverUser Test', ->
+  beforeEach ->
+    wipeCurrentProject()
+
   it 'should allow a user to list other users in a project', ->
     testUser = new Weaver.User('in-project', 'testpassword', 'email@dontevenvalidate.com')
     testUser2 = new Weaver.User('in-project2', 'testpassword', 'email@dontevenvalidate.com')

--- a/test/globalize.coffee
+++ b/test/globalize.coffee
@@ -6,10 +6,10 @@ chai         = require('chai')
 sinon        = require('sinon')
 
 # Use chai as promised
-chai.use(require('chai-as-promised'));
+chai.use(require('chai-as-promised'))
 
 # You need to call chai.should() before being able to wrap everything with should
-chai.should();
+chai.should()
 
 # From libs
 global.expect  = chai.expect

--- a/test/test-suite.coffee
+++ b/test/test-suite.coffee
@@ -25,10 +25,10 @@ after ->
     weaver.wipe()
   )
 
-# Runs after each test in each file
+# Previously ran before each test in each file
 # NOTE THAT THIS BREAKS THE ACL ASSOCIATED WITH A PROJECT TESTING ON
 
-beforeEach ->
+wipeCurrentProject = ->
   weaver.signInWithUsername('admin', 'admin')
   .then(->weaver.getCoreManager().wipeUsers())
   .then(->weaver.currentProject().wipe())

--- a/test/test-suite.coffee
+++ b/test/test-suite.coffee
@@ -34,4 +34,4 @@ wipeCurrentProject = ->
   .then(->weaver.currentProject().wipe())
   .then(->weaver.currentProject().unfreeze())
 
-module.exports = weaver
+module.exports = { weaver, wipeCurrentProject }


### PR DESCRIPTION
Makes wiping of the current project an optional thing that needs to be called explicitly in every test that requires a clean database in order to speed up test speed.

Also fixes Weaver.Node.load(undefined).