### PR TITLE
Operations will now be executed in batches of 500 (specified by Gijs …

### DIFF
--- a/src/CoreManager.coffee
+++ b/src/CoreManager.coffee
@@ -67,13 +67,9 @@ class CoreManager
     )
 
   executeOperations: (allOperations, target) ->
-    if (allOperations.length <= @maxBatchSize)
-      @POST('write', {operations: allOperations}, target)
-    else
-      operations = allOperations.splice(0, @maxBatchSize)
-      @POST('write', {operations}, target).then ( =>
-        @executeOperations(allOperations, target)
-      )
+    Promise.mapSeries(_.chunk(allOperations, @maxBatchSize), (operations) =>
+      @POST('write', {operations}, target)
+    )
 
 #  serverVersion: ->
 #    @POST('application.version')

--- a/src/CoreManager.coffee
+++ b/src/CoreManager.coffee
@@ -68,8 +68,7 @@ class CoreManager
 
   executeOperations: (allOperations, target) ->
     if (allOperations.length <= @maxBatchSize)
-      operations = allOperations
-      @POST('write', {operations}, target)
+      @POST('write', {operations: allOperations}, target)
     else
       operations = allOperations.splice(0, @maxBatchSize)
       @POST('write', {operations}, target).then ( =>

--- a/src/CoreManager.coffee
+++ b/src/CoreManager.coffee
@@ -16,6 +16,7 @@ class CoreManager
     @currentProject = null
     @operationsQueue = Promise.resolve()
     @timeOffset = 0
+    @maxBatchSize = 500
 
   connect: (endpoint, @options) ->
     defaultOptions =
@@ -65,9 +66,15 @@ class CoreManager
       localTime - serverTime
     )
 
-
-  executeOperations: (operations, target) ->
-    @POST('write', {operations}, target)
+  executeOperations: (allOperations, target) ->
+    if (allOperations.length <= @maxBatchSize)
+      operations = allOperations
+      @POST('write', {operations}, target)
+    else
+      operations = allOperations.splice(0, @maxBatchSize)
+      @POST('write', {operations}, target).then ( =>
+        @executeOperations(allOperations, target)
+      )
 
 #  serverVersion: ->
 #    @POST('application.version')

--- a/test/WeaverNode.test.coffee
+++ b/test/WeaverNode.test.coffee
@@ -490,7 +490,7 @@ describe 'WeaverNode test', ->
     ).finally(->
       weaver.setOptions({ignoresOutOfDate: false})
     )
-  
+
   it 'should reject out-of-sync relation updates by default', ->
     a = new Weaver.Node()
     alsoA = undefined
@@ -509,7 +509,7 @@ describe 'WeaverNode test', ->
       alsoA.relation('rel').update(b, d)
       alsoA.save()
     ).should.eventually.be.rejected
-  
+
   it 'should allow out-of-sync relation updates if the ignoresOutOfDate flag is set', ->
     weaver.setOptions({ignoresOutOfDate: true})
     a = new Weaver.Node()
@@ -530,4 +530,63 @@ describe 'WeaverNode test', ->
       alsoA.save()
     ).finally(->
       weaver.setOptions({ignoresOutOfDate: false})
+    )
+
+  it 'should execute normally with a small amount of operations', ->
+    weaver.setOptions({ignoresOutOfDate: true})
+    a = new Weaver.Node()
+    alsoA = undefined
+    b = new Weaver.Node()
+    c = new Weaver.Node()
+    d = new Weaver.Node()
+    a.relation('rel').add(b)
+
+    Weaver.Node.batchSave([a, b, c, d]).then(->
+      Weaver.Node.load(a.id())
+    ).then((node) ->
+      alsoA = node
+      a.relation('rel').update(b, c)
+      a.save()
+    ).then(->
+      alsoA.relation('rel').update(b, d)
+      alsoA.save()
+    ).finally(->
+      weaver.setOptions({ignoresOutOfDate: false})
+    )
+
+  it 'should execute per batch with a high amount of operations', ->
+    ###
+    In this test there is still a low amount of operations, but the batchsize is reduced to 2.
+    This test will have 9 operations which lead to 5 batches (4x2 + 1x1)
+    Same test as it 'should clone a node', but with reduced batchsize.
+    ###
+
+    cm = Weaver.getCoreManager()
+    cm.maxBatchSize = 2
+    a = new Weaver.Node('clonea2')
+    b = new Weaver.Node('cloneb2')
+    c = new Weaver.Node('clonec2')
+    cloned = null
+
+    a.set('name', 'Foo')
+    b.set('name', 'Bar')
+    c.set('name', 'Dear')
+
+    a.relation('to').add(b)
+    b.relation('to').add(c)
+    c.relation('to').add(a)
+
+    Weaver.Node.batchSave([a,b,c])
+    .then(->
+      a.clone('cloned-a2')
+    ).then( ->
+      Weaver.Node.load('cloned-a2')
+    ).then((cloned) ->
+      assert.notEqual(cloned.id(), a.id())
+      assert.equal(cloned.get('name'), 'Foo')
+      to = value for key, value of cloned.relation('to').nodes
+      assert.equal(to.id(), b.id())
+      Weaver.Node.load(c.id())
+    ).then((node) ->
+      assert.isDefined(node.relation('to').nodes['cloned-a2'])
     )


### PR DESCRIPTION
Operations will now be executed in batches of 500 (specified by Gijs as initial setting)

Tested through WeaverNode with operation arrays up to 9 and batches of 1-4.
No additional tests written