### PR TITLE
allows node.clone(undefined, 'hasChild')

### DIFF
--- a/src/CoreManager.coffee
+++ b/src/CoreManager.coffee
@@ -74,7 +74,7 @@ class CoreManager
 #  serverVersion: ->
 #    @POST('application.version')
 
-  cloneNode: (sourceId, targetId, relationsToTraverse) ->
+  cloneNode: (sourceId, targetId = cuid(), relationsToTraverse) ->
     @POST('node.clone', { sourceId, targetId, relationsToTraverse})
 
   serverVersion: ->


### PR DESCRIPTION
allows node.clone(undefined, 'hasChild')

previously, a target id had to be specified for a clone.