### PR TITLE
Add alwaysLoadRelations functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "com_weaverplatform": {
     "requiredServerVersion": "^3.0.10-beta.1",
-    "requiredConnectorVersion": "~0.0.26"
+    "requiredConnectorVersion": "~0.0.27-SNAPSHOT.0"
   },
   "main": "lib/Weaver.js",
   "license": "GPL-3.0",

--- a/src/WeaverQuery.coffee
+++ b/src/WeaverQuery.coffee
@@ -30,7 +30,7 @@ class WeaverQuery
     @_select             = undefined
     @_selectOut          = []
     @_selectRecursiveOut = []
-    @_alwaysLoad         = []
+    @_alwaysLoadRelations= []
     @_noRelations        = true
     @_noAttributes       = true
     @_count              = false
@@ -249,8 +249,8 @@ class WeaverQuery
     @_selectRecursiveOut = relationKeys
     @
 
-  alwaysLoad: (relationKeys...) ->
-    @_alwaysLoad.push(i) for i in relationKeys
+  alwaysLoadRelations: (relationKeys...) ->
+    @_alwaysLoadRelations.push(i) for i in relationKeys
     @
 
   hollow: (value) ->

--- a/src/WeaverQuery.coffee
+++ b/src/WeaverQuery.coffee
@@ -30,6 +30,7 @@ class WeaverQuery
     @_select             = undefined
     @_selectOut          = []
     @_selectRecursiveOut = []
+    @_alwaysLoad         = []
     @_noRelations        = true
     @_noAttributes       = true
     @_count              = false
@@ -246,6 +247,10 @@ class WeaverQuery
 
   selectRecursiveOut: (relationKeys...) ->
     @_selectRecursiveOut = relationKeys
+    @
+
+  alwaysLoad: (relationKeys...) ->
+    @_alwaysLoad.push(i) for i in relationKeys
     @
 
   hollow: (value) ->

--- a/test-server/docker-compose.yml
+++ b/test-server/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     - "5432"
 
   postgresql-connector:
-    image: sysunite/weaver-database-postgresql:0.0.26
+    image: sysunite/weaver-database-postgresql:0.0.27-SNAPSHOT.0
     links:
     - postgres
     expose:

--- a/test/WeaverQuerySingleNetwork.test.coffee
+++ b/test/WeaverQuerySingleNetwork.test.coffee
@@ -187,7 +187,7 @@ describe 'WeaverQuery with single Network', ->
     )
 
   it 'should support always including a relation of non-loaded relations', ->
-    new Weaver.Query().alwaysLoad('is-brand-of').restrict(ferrari.id()).find().then((nodes) ->
+    new Weaver.Query().alwaysLoadRelations('is-brand-of').restrict(ferrari.id()).find().then((nodes) ->
       expect(i.id() for i in nodes).to.eql([ferrari.id()])
       expect(nodes[0])
       .to.have.property('relations')
@@ -201,7 +201,7 @@ describe 'WeaverQuery with single Network', ->
     )
 
   it 'should support selectOut always including a relation of non-loaded relations', ->
-    new Weaver.Query().selectOut('drives').alwaysLoad('is-brand-of').restrict(vettel.id()).find().then((nodes) ->
+    new Weaver.Query().selectOut('drives').alwaysLoadRelations('is-brand-of').restrict(vettel.id()).find().then((nodes) ->
       expect(i.id() for i in nodes).to.eql([vettel.id()])
       expect(nodes[0])
       .to.have.property('relations')

--- a/test/WeaverQuerySingleNetwork.test.coffee
+++ b/test/WeaverQuerySingleNetwork.test.coffee
@@ -12,6 +12,8 @@ describe 'WeaverQuery with single Network', ->
   ferrari          = new Weaver.Node()
   car              = new Weaver.Node()
   motorizedVehicle = new Weaver.Node()
+  wheel            = new Weaver.Node()
+  pirelli          = new Weaver.Node()
 
   tree.set('testset', '1')
 
@@ -35,17 +37,23 @@ describe 'WeaverQuery with single Network', ->
   ferrari.relation('is-a').add(car)
   car.relation('is-a').add(motorizedVehicle)
 
+  wheel.set('testset', '2')
+  pirelli.set('testset', '2')
+
+  pirelli.relation('is-brand-of').add(wheel)
+  ferrari.relation('hasTires').add(pirelli)
+
   before ->
     wipeCurrentProject().then( ->
       Promise.all([ferrari.save(), garden.save()])
     )
 
   it 'should support wildcard with nested Weaver.Query values', ->
+    # Get all nodes which have any relation in from a node that is-a car
     new Weaver.Query()
     .hasRelationIn('*', new Weaver.Query().hasRelationOut('is-a', car))
     .find().then((nodes) ->
-      expect(nodes).to.have.length.be(1)
-      expect(nodes[0].id()).to.equal(car.id())
+      expect(i.id() for i in nodes).to.eql([ car.id(), pirelli.id() ])
     )
 
   it 'should support wildcard relation hasRelationOut', ->

--- a/test/WeaverQuerySingleNetwork.test.coffee
+++ b/test/WeaverQuerySingleNetwork.test.coffee
@@ -180,5 +180,13 @@ describe 'WeaverQuery with single Network', ->
   it 'should support always including a relation of non-loaded relations', ->
     new Weaver.Query().alwaysLoad('is-brand-of').restrict(ferrari.id()).find().then((nodes) ->
       expect(i.id() for i in nodes).to.eql([ferrari.id()])
-      console.log nodes[0].relations.hasTires
+      expect(nodes[0])
+      .to.have.property('relations')
+      .to.have.property('hasTires')
+      .to.have.property('nodes')
+      .to.have.property(pirelli.id())
+      .to.have.property('relations')
+      .to.have.property('is-brand-of')
+      .to.have.property('nodes')
+      .to.have.property(wheel.id())
     )

--- a/test/WeaverQuerySingleNetwork.test.coffee
+++ b/test/WeaverQuerySingleNetwork.test.coffee
@@ -176,3 +176,9 @@ describe 'WeaverQuery with single Network', ->
       expect(res).to.have.length.be(1)
       expect(res[0].id()).to.equal(tree.id())
     )
+
+  it 'should support always including a relation of non-loaded relations', ->
+    new Weaver.Query().alwaysLoad('is-brand-of').restrict(ferrari.id()).find().then((nodes) ->
+      expect(i.id() for i in nodes).to.eql([ferrari.id()])
+      console.log nodes[0].relations.hasTires
+    )

--- a/test/WeaverQuerySingleNetwork.test.coffee
+++ b/test/WeaverQuerySingleNetwork.test.coffee
@@ -14,6 +14,8 @@ describe 'WeaverQuery with single Network', ->
   motorizedVehicle = new Weaver.Node()
   wheel            = new Weaver.Node()
   pirelli          = new Weaver.Node()
+  vettel           = new Weaver.Node()
+  hamilton         = new Weaver.Node()
 
   tree.set('testset', '1')
 
@@ -43,9 +45,16 @@ describe 'WeaverQuery with single Network', ->
   pirelli.relation('is-brand-of').add(wheel)
   ferrari.relation('hasTires').add(pirelli)
 
+  vettel.set('testset', '2')
+  vettel.relation('drives').add(ferrari)
+
+  hamilton.set('testset', '2')
+  vettel.relation('beats').add(hamilton)
+  hamilton.relation('beats').add(vettel)
+
   before ->
     wipeCurrentProject().then( ->
-      Promise.all([ferrari.save(), garden.save()])
+      Promise.all([vettel.save(), garden.save()])
     )
 
   it 'should support wildcard with nested Weaver.Query values', ->
@@ -181,6 +190,24 @@ describe 'WeaverQuery with single Network', ->
     new Weaver.Query().alwaysLoad('is-brand-of').restrict(ferrari.id()).find().then((nodes) ->
       expect(i.id() for i in nodes).to.eql([ferrari.id()])
       expect(nodes[0])
+      .to.have.property('relations')
+      .to.have.property('hasTires')
+      .to.have.property('nodes')
+      .to.have.property(pirelli.id())
+      .to.have.property('relations')
+      .to.have.property('is-brand-of')
+      .to.have.property('nodes')
+      .to.have.property(wheel.id())
+    )
+
+  it 'should support selectOut always including a relation of non-loaded relations', ->
+    new Weaver.Query().selectOut('drives').alwaysLoad('is-brand-of').restrict(vettel.id()).find().then((nodes) ->
+      expect(i.id() for i in nodes).to.eql([vettel.id()])
+      expect(nodes[0])
+      .to.have.property('relations')
+      .to.have.property('drives')
+      .to.have.property('nodes')
+      .to.have.property(ferrari.id())
       .to.have.property('relations')
       .to.have.property('hasTires')
       .to.have.property('nodes')


### PR DESCRIPTION
Required for Weaver.Model to load the _proto relation for all nodes.