### PR TITLE
Patch WeaverModel to support init with defined classes

### DIFF
--- a/src/WeaverModel.coffee
+++ b/src/WeaverModel.coffee
@@ -57,15 +57,18 @@ class WeaverModel
 
   _bootstrapClasses: (existingNodes) ->
     promises = []
+    nodesToCreate = {}
 
     for modelClassName of @definition.classes when not existingNodes.includes("#{@definition.name}:#{modelClassName}")
-      promises.push(new Weaver.Node("#{@definition.name}:#{modelClassName}").save())
+      node = new Weaver.Node("#{@definition.name}:#{modelClassName}")
+      nodesToCreate[node.id()] = node
 
     for className, classObj of @definition.classes when classObj.init?
       ModelClass = @[className]
       for itemName in classObj.init when not existingNodes.includes("#{@definition.name}:#{itemName}")
-        node = new ModelClass("#{@definition.name}:#{itemName}")
-        promises.push(node.save())
+        nodesToCreate["#{@definition.name}:#{itemName}"] = new ModelClass("#{@definition.name}:#{itemName}")
+
+    promises.push(node.save()) for id, node of nodesToCreate
 
     Promise.all(promises)
 


### PR DESCRIPTION
This patch allows us to do this in the model:

```yml
ClassOfClass:
    init: [
      ClassOfAspect,
      ClassOfRequirementStatus,
      ClassOfStatementStatus,
      ClassOfRequirementType,
      ClassOfStatementType,
      ClassOfRegionInSpace,
      ClassOfDocumentRoleType
    ]

  ClassOfAspect:
```

It won't try to double create nodes that are in an init and also in the class definition, and at the same time it will create the correct prototype relations for init.