### PR TITLE
adds some Weaver.Node helper methods

### DIFF
--- a/src/WeaverNode.coffee
+++ b/src/WeaverNode.coffee
@@ -113,6 +113,15 @@ class WeaverNode
   relations: ->
     @_relations
 
+  isRelationPresent: (key, objId)->
+    for node in @relation(key).all()
+      return true if node.id() is objId
+    false
+
+  getRelation: (key, objId)->
+    for node in @relation(key).all()
+      return node if node.id() is objId
+
   _getAttributeValue: (attribute) ->
     if attribute.dataType is 'date'
       return new Date(attribute.value)

--- a/src/WeaverNode.coffee
+++ b/src/WeaverNode.coffee
@@ -113,6 +113,9 @@ class WeaverNode
   relations: ->
     @_relations
 
+  relationNodes: (key)->
+    @relation(key).relationNodes
+
   isRelationPresent: (key, objId)->
     for node in @relation(key).all()
       return true if node.id() is objId

--- a/test/WeaverNode.test.coffee
+++ b/test/WeaverNode.test.coffee
@@ -320,6 +320,16 @@ describe 'WeaverNode test', ->
     assert.equal(a.isRelationPresent('rel', 'null'), false)
     assert.equal(a.isRelationPresent('null', b.id()), false)
 
+  it 'should return the relation nodes', ->
+    a = new Weaver.Node('a')
+    b = new Weaver.Node('b')
+
+    rel = a.relation('rel').add(b)
+
+    assert.equal(a.relationNodes('rel').length, 1)
+    assert.equal(a.relationNodes('rel')[0].id(), rel.id())
+    assert.equal(a.relationNodes('null').length, 0)
+
   it 'should not blow up when saving in circular chain', ->
     a = new Weaver.Node()
     b = new Weaver.Node()

--- a/test/WeaverNode.test.coffee
+++ b/test/WeaverNode.test.coffee
@@ -300,6 +300,26 @@ describe 'WeaverNode test', ->
       assert.equal(loadedNode.relation('rel').first().id(), b.id())
     )
 
+  it 'should return a specific relation', ->
+    a = new Weaver.Node()
+    b = new Weaver.Node()
+
+    a.relation('rel').add(b)
+
+    assert.equal(a.getRelation('rel', b.id()).id(), b.id())
+    assert.equal(a.getRelation('rel', 'null'), undefined)
+    assert.equal(a.getRelation('null', b.id()), undefined)
+
+  it 'should check existence of a specific relation', ->
+    a = new Weaver.Node()
+    b = new Weaver.Node()
+
+    a.relation('rel').add(b)
+
+    assert.equal(a.isRelationPresent('rel', b.id()), true)
+    assert.equal(a.isRelationPresent('rel', 'null'), false)
+    assert.equal(a.isRelationPresent('null', b.id()), false)
+
   it 'should not blow up when saving in circular chain', ->
     a = new Weaver.Node()
     b = new Weaver.Node()


### PR DESCRIPTION
Some helper methods to avoid having to loop through all those `node.relation().all()` arrays