### PR TITLE
Optionally specify cardinality for a relation range individually

### DIFF
--- a/src/WeaverModelRelation.coffee
+++ b/src/WeaverModelRelation.coffee
@@ -1,6 +1,7 @@
 cuid        = require('cuid')
 Promise     = require('bluebird')
 Weaver      = require('./Weaver')
+_           = require('lodash')
 
 class WeaverModelRelation extends Weaver.Relation
 
@@ -29,11 +30,18 @@ class WeaverModelRelation extends Weaver.Relation
       ranges
 
     totalRanges = []
-    for range in @relationDefinition.range
+    for range in @_getRangeKeys()
       totalRanges.push(range)
       totalRanges = totalRanges.concat(addSubRange(range))
 
     totalRanges
+
+  _getRangeKeys: ->
+    range = @relationDefinition.range
+    if _.isArray(range)
+      range
+    else
+      _.keys(range)
 
   _getClassName: (node) ->
     node.className or

--- a/test-server/weaver-server-models/test-model.yml
+++ b/test-server/weaver-server-models/test-model.yml
@@ -56,8 +56,11 @@ classes:
       hasFriend:
         range: [Person]
       comesFrom:
-        range: [Country, City]
-        card: [0,1]
+        range:
+          Country:
+            card: [0,1]
+          City:
+            card: [0,2]
       hasHead:
         range: [Head]
       hasRelation:

--- a/test-server/weaver-server-models/test-model.yml
+++ b/test-server/weaver-server-models/test-model.yml
@@ -57,10 +57,8 @@ classes:
         range: [Person]
       comesFrom:
         range:
-          Country:
-            card: [0,1]
-          City:
-            card: [0,2]
+          Country: [0,1]
+          City: [0,2]
       hasHead:
         range: [Head]
       hasRelation:


### PR DESCRIPTION
PoC for specifying cardinality on a range individually. This is optional (the old way works still), and cardinality is not enforced.