### PR TITLE
Do not use model graph for instances

### DIFF
--- a/Changelist.md
+++ b/Changelist.md
@@ -2,6 +2,8 @@
 
 - Do not consider e.g. owl:Class node a valid range for selecting the right 
   constructor in processing a ModelQuery resultset.
+- Instances from any ModelClass extension should not be put in the model
+  graph. By default in the default graph, or set with argument.
 
 ## 6.1.2
 - Load already existing instances from the init block of a Model (now for

--- a/src/WeaverModel.coffee
+++ b/src/WeaverModel.coffee
@@ -64,11 +64,11 @@ class WeaverModel
       @[className] = eval(js)
       @[className] = @[className] extends Weaver.ModelClass
       @[className].defineBy(@, @definition, className, classDefinition, totalClassDefinition)
-      load = (loadClass) => (nodeId) =>
+      load = (loadClass) => (nodeId, graph) =>
         new Weaver.ModelQuery(@)
           .class(@[loadClass])
           .restrict(nodeId)
-          .inGraph(@getGraph())
+          .inGraph(graph)
           .first(@[loadClass])
 
       @[className].load = load(className)

--- a/src/WeaverModel.coffee
+++ b/src/WeaverModel.coffee
@@ -13,13 +13,13 @@ class WeaverModel
 
       js = """
         (function() {
-          function #{className}(nodeId) {
+          function #{className}(nodeId, graph) {
             this.model                = #{className}.model;
             this.definition           = #{className}.definition;
             this.className            = "#{className}";
             this.classDefinition      = #{className}.classDefinition;
             this.totalClassDefinition = #{className}.totalClassDefinition;
-            #{className}.__super__.constructor.call(this, nodeId);
+            #{className}.__super__.constructor.call(this, nodeId, graph);
           };
 
           #{className}.defineBy = function(model, definition, className, classDefinition, totalClassDefinition) {

--- a/src/WeaverModel.coffee
+++ b/src/WeaverModel.coffee
@@ -115,7 +115,7 @@ class WeaverModel
       ModelClass = @[className]
 
       for itemName in classObj.init
-        node = new ModelClass("#{@definition.name}:#{itemName}")
+        node = new ModelClass("#{@definition.name}:#{itemName}", @getGraph())
         if not existingNodes.includes("#{@definition.name}:#{itemName}")
           nodesToCreate[node.id()] = node
         else

--- a/src/WeaverModelClass.coffee
+++ b/src/WeaverModelClass.coffee
@@ -20,9 +20,8 @@ class WeaverModelClass extends Weaver.Node
   @getNode: ->
     Weaver.Node.getFromGraph(@classId(), @model.getGraph())
 
-  constructor: (nodeId)->
-    super(nodeId, @model.getGraph())
-
+  constructor: (nodeId, graph)->
+    super(nodeId, graph)
 
     # Add type definition to model class
     classId = @constructor.classId()

--- a/test/WeaverModel.test.coffee
+++ b/test/WeaverModel.test.coffee
@@ -262,7 +262,7 @@ describe 'WeaverModel test', ->
         )
 
       it 'should add an existing node to a model', ->
-        person = new Weaver.Node(undefined, model.getGraph())
+        person = new Weaver.Node()
         model.Person.addMember(person)
         person.save().then(->
           model.Person.load(person.id())
@@ -271,7 +271,7 @@ describe 'WeaverModel test', ->
         )
 
       it 'should add an existing node to an other model', ->
-        tree = new Weaver.Node(undefined, model.getGraph())
+        tree = new Weaver.Node()
         tree.relation('hasLeaf').add(new Weaver.Node())
         model.Country.addMember(tree)
 
@@ -282,7 +282,7 @@ describe 'WeaverModel test', ->
         )
 
       it 'should add an existing node to two other models', ->
-        tree = new Weaver.Node(undefined, model.getGraph())
+        tree = new Weaver.Node()
         tree.relation('hasLeaf').add(new Weaver.Node())
         model.Country.addMember(tree)
         model.Person.addMember(tree)

--- a/test/WeaverModelQuery.test.coffee
+++ b/test/WeaverModelQuery.test.coffee
@@ -13,7 +13,7 @@ describe 'WeaverModelQuery test', ->
       model = m
       model.bootstrap()
     ).then(->
-      person = new model.Person()
+      person = new model.Person('jondoeid', 'person-graph')
       person.set('fullName', 'John Doe')
       person.save()
     )
@@ -26,6 +26,7 @@ describe 'WeaverModelQuery test', ->
       expect(instances).to.have.length.be(1)
       assert.equal(instances[0].constructor, model.Person)
       assert.equal(instances[0].get('fullName'), 'John Doe')
+      assert.equal(instances[0].getGraph(), 'person-graph')
     )
 
   describe 'with a default model', ->


### PR DESCRIPTION
Instances from any ModelClass extension should not be put in the model graph. By default in the default graph, or set with argument.

I certify that:
- [x] The automated build passes on the branch this pull request is from
- [x] My change is documented in the Changelist.md
- [x] Any new dockerimages this build depends on are properly tagged on github
- [x] I shall not merge until the travis build is green and the PR is accepted by
  another developer
- [x] I shall promptly fix/reply to comments, as I know PRs are not :fire: and
  forget
- [x] I shall keep my branch updated with any intermediate changes to the
  target branch
- [x] This is a quality PR
- [x] I got to the end of this list
