### PR TITLE
Weav 295 get invalid attribute

### DIFF
--- a/Changelist.md
+++ b/Changelist.md
@@ -1,5 +1,9 @@
 # Changelist
 
+## 6.3.3
+- Fixes ModelClass instances raising an exception when being asked about an
+  attribute they don't have, instead undefined is returned
+
 ## 6.3.2
 - Fixes a bug where calling load() on an instance of ModelClass would destroy
   the ModelClass functions

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "weaver-sdk",
   "main": "dist/weaver-sdk.full.js",
-  "version": "6.3.2",
+  "version": "6.3.3-beta.0",
   "homepage": "https://github.com/weaverplatform/weaver-sdk-js",
   "authors": [
     "Mohamad Alamili <mohamad@sysunite.com>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weaver-sdk",
-  "version": "6.3.2",
+  "version": "6.3.3-beta.0",
   "description": "Weaver SDK for JavaScript",
   "author": {
     "name": "Mohamad Alamili",

--- a/src/WeaverModelClass.coffee
+++ b/src/WeaverModelClass.coffee
@@ -48,7 +48,7 @@ class WeaverModelClass extends Weaver.Node
   _loadRelationFromQuery: (key, instance, nodeId, graph)->
     if @totalClassDefinition.relations[key]?
       @relation(key).add(instance, nodeId, false, graph)
-    else 
+    else
       @nodeRelation(key).add(instance, nodeId, false, graph)
 
 
@@ -121,7 +121,7 @@ class WeaverModelClass extends Weaver.Node
     defs = []
     if node instanceof Weaver.ModelClass
       defs = (def.id() for def in node.nodeRelation(@model.getMemberKey()).all())
-    else  
+    else
       defs = (def.id() for def in node.relation(@model.getMemberKey()).all())
     defs
 
@@ -152,9 +152,10 @@ class WeaverModelClass extends Weaver.Node
     super.get(args...)
 
   get: (field) ->
-    key = @_getAttributeKey(field)
-    return null if not key?
-    super(key)
+    try
+      super(@_getAttributeKey(field))
+    catch
+      undefined
 
   nodeSet: (args...)->
     super.set(args...)
@@ -175,7 +176,7 @@ class WeaverModelClass extends Weaver.Node
     definition = @definition
     relationDefinition = @totalClassDefinition.relations[key]
     classRelation = class extends Weaver.ModelRelation
-      
+
       constructor: (parent, key)->
         super(parent, key)
         @modelKey           = modelKey
@@ -183,7 +184,7 @@ class WeaverModelClass extends Weaver.Node
         @className          = className
         @definition         = definition
         @relationDefinition = relationDefinition
-        
+
     super(relationKey, classRelation)
 
   save: (project) ->

--- a/test/WeaverModel.test.coffee
+++ b/test/WeaverModel.test.coffee
@@ -145,6 +145,10 @@ describe 'WeaverModel test', ->
       person.set('fullName', "John Doe")
       assert.throws((-> person.get('hasFullName')))
 
+    it 'should not deny getting invalid attributes but instead return undefined', ->
+      person = new model.Person()
+      expect(person.get("totallyNotAnAttributeOfTheModel")).to.be.undefined
+
     it 'should bootstrap a model', ->
       model.bootstrap().then(->
         new Weaver.Query().restrict('test-model:Person').find()

--- a/test/WeaverModel.test.coffee
+++ b/test/WeaverModel.test.coffee
@@ -143,7 +143,7 @@ describe 'WeaverModel test', ->
       Person = model.Person
       person = new Person()
       person.set('fullName', "John Doe")
-      assert.throws((-> person.get('hasFullName')))
+      expect(person.get('hasFullName')).to.be.undefined
 
     it 'should not deny getting invalid attributes but instead return undefined', ->
       person = new model.Person()


### PR DESCRIPTION

Fixes ModelClass instances raising an exception when being asked about an attribute they don't have, instead undefined is returned

I certify that:
- [x] The automated build passes on the branch this pull request is from
- [x] My change is documented in the Changelist.md
- [x] Any new dockerimages this build depends on are properly tagged on github
- [x] I shall not merge until the travis build is green and the PR is accepted by
  another developer
- [x] I shall promptly fix/reply to comments, as I know PRs are not :fire: and
  forget
- [x] I shall keep my branch updated with any intermediate changes to the
  target branch
- [x] This is a quality PR
- [x] I got to the end of this list
