### PR TITLE
Pending writes get lost 2

### DIFF
--- a/Changelist.md
+++ b/Changelist.md
@@ -1,5 +1,9 @@
 # Changelist
 
+# develop
+- Do not use the id of the node as identifier in cycle detection for 
+  collecting the pending writes 
+
 # 6.4.5
 - Put member relationship of new modelclass instance in the instance graph, 
   not in the model graph

--- a/src/WeaverNode.coffee
+++ b/src/WeaverNode.coffee
@@ -308,19 +308,22 @@ class WeaverNode
       i.__pendingOpNode = @ for i in operations
 
     for key, relation of @_relations
-      for node in relation.nodes
-        if node not in collected
-          collected.push(node)
-          operations = operations.concat(node._collectPendingWrites(collected, cleanup))
+      if relation.nodes?
+        for node in relation.nodes
+          if node not in collected
+            collected.push(node)
+            operations = operations.concat(node._collectPendingWrites(collected, cleanup))
 
-      operations = operations.concat(relation.pendingWrites)
+      if relation.pendingWrites?
+        operations = operations.concat(relation.pendingWrites)
 
-      for node in relation.relationNodes
-        if node not in collected
-          collected.push(node)
-          operations = operations.concat(node._collectPendingWrites(collected, cleanup))
+      if relation.relationNodes?
+        for node in relation.relationNodes
+          if node not in collected
+            collected.push(node)
+            operations = operations.concat(node._collectPendingWrites(collected, cleanup))
 
-      if cleanup
+      if cleanup and relation.pendingWrites?
         i.__pendingOpNode = relation for i in relation.pendingWrites
         relation.pendingWrites = []
 

--- a/src/WeaverNode.coffee
+++ b/src/WeaverNode.coffee
@@ -302,32 +302,27 @@ class WeaverNode
     # Register to keep track which nodes have been collected to prevent recursive blowup
     collected.push(@) if @ not in collected
     operations = @pendingWrites
+    if not operations?
+      return []
 
     if cleanup
       @pendingWrites = []
       i.__pendingOpNode = @ for i in operations
 
     for key, relation of @_relations
-      if relation.nodes?
-        for node in relation.nodes
-          if node not in collected
-            collected.push(node)
-            operations = operations.concat(node._collectPendingWrites(collected, cleanup))
+      for node in relation.nodes when node not in collected
+        collected.push(node)
+        operations = operations.concat(node._collectPendingWrites(collected, cleanup))
 
-      if relation.pendingWrites?
-        operations = operations.concat(relation.pendingWrites)
+      operations = operations.concat(relation.pendingWrites)
 
-      if relation.relationNodes?
-        for node in relation.relationNodes
-          if node not in collected
-            collected.push(node)
-            operations = operations.concat(node._collectPendingWrites(collected, cleanup))
+      for node in relation.relationNodes when node not in collected
+          collected.push(node)
+          operations = operations.concat(node._collectPendingWrites(collected, cleanup))
 
-      if cleanup and relation.pendingWrites?
+      if cleanup
         i.__pendingOpNode = relation for i in relation.pendingWrites
         relation.pendingWrites = []
-
-
 
     operations
 

--- a/src/WeaverNode.coffee
+++ b/src/WeaverNode.coffee
@@ -298,9 +298,9 @@ class WeaverNode
     @_collectPendingWrites(undefined, false)
 
   # Go through each relation and recursively add all pendingWrites per relation AND that of the objects
-  _collectPendingWrites: (collected = {}, cleanup=true) ->
+  _collectPendingWrites: (collected = [], cleanup=true) ->
     # Register to keep track which nodes have been collected to prevent recursive blowup
-    collected[@id()] = true
+    collected.push(@) if @ not in collected
     operations = @pendingWrites
 
     if cleanup
@@ -309,15 +309,15 @@ class WeaverNode
 
     for key, relation of @_relations
       for node in relation.nodes
-        if node.id()? and not collected[node.id()]
-          collected[node.id()] = true
+        if node not in collected
+          collected.push(node)
           operations = operations.concat(node._collectPendingWrites(collected, cleanup))
 
       operations = operations.concat(relation.pendingWrites)
 
       for node in relation.relationNodes
-        if node.id()? and not collected[node.id()]
-          collected[node.id()] = true
+        if node not in collected
+          collected.push(node)
           operations = operations.concat(node._collectPendingWrites(collected, cleanup))
 
       if cleanup


### PR DESCRIPTION
Do not use the id of the node as identifier in cycle detection for collecting the pending writes 

I certify that:
- [x] The automated build passes on the branch this pull request is from
- [x] My change is documented in the Changelist.md
- [x] Any new dockerimages this build depends on are properly tagged on github
- [x] I shall not merge until the travis build is green and the PR is accepted by
  another developer
- [x] I shall promptly fix/reply to comments, as I know PRs are not :fire: and
  forget
- [x] I shall keep my branch updated with any intermediate changes to the
  target branch
- [x] This is a quality PR
- [x] I got to the end of this list
