### PR TITLE
Adding test to cover: Allowing a user to read metadata from project w…

### DIFF
--- a/Changelist.md
+++ b/Changelist.md
@@ -1,8 +1,5 @@
 # Changelist
 
-## 7.3.2
-- Adding test to cover: Allowing a user to read metadata from project without administration access for project
-
 ## 7.3.1
 - Set target project in booststrap query.
 

--- a/Changelist.md
+++ b/Changelist.md
@@ -1,5 +1,8 @@
 # Changelist
 
+## 7.3.2
+- Adding test to cover: Allowing a user to read metadata from project without administration access for project
+
 ## 7.3.1
 - Set target project in booststrap query.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weaver-sdk",
-  "version": "7.3.2",
+  "version": "7.3.1-beta.0",
   "description": "Weaver SDK for JavaScript",
   "author": {
     "name": "Mohamad Alamili",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weaver-sdk",
-  "version": "7.3.1",
+  "version": "7.3.2",
   "description": "Weaver SDK for JavaScript",
   "author": {
     "name": "Mohamad Alamili",
@@ -9,7 +9,7 @@
   },
   "com_weaverplatform": {
     "requiredConnectorVersion": "^4.8.1",
-    "requiredServerVersion": "^3.12.0 || ^3.12.1-beta.0"
+    "requiredServerVersion": "^3.12.0 || ^3.13.0-beta.1"
   },
   "main": "lib/Weaver.js",
   "license": "GPL-3.0",

--- a/test-server/docker-compose.yml
+++ b/test-server/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     - "9000:9000"
 
   weaver-server:
-    image: sysunite/weaver-server:3.12.2
+    image: sysunite/weaver-server:3.13.0-beta.1
     expose:
     - "9487"
     ports:

--- a/test/WeaverProject.test.coffee
+++ b/test/WeaverProject.test.coffee
@@ -98,7 +98,33 @@ describe 'WeaverProject Test', ->
     ).then(->
       p.getMetadata(bundleName, appMetadata.appName)
     ).should.be.rejectedWith("No metadata on project #{p.name} for bundleKey fooApps or key FooBarApp")
-  
+ 
+  it 'should be able for a user to retrieve metadata without project administration access', ->
+    p = weaver.currentProject()
+    appMetadata =
+      appName: 'FooBarApp'
+      appVersion: '0.2.1-fooBar-b'
+      desireSDK: '6.0.1-weaver'
+    user = new Weaver.User('testuser', 'testpass', 'test@example.com')
+    bundleName = 'apps'
+    p.addMetadata(bundleName, appMetadata.appName, appMetadata).then(->
+      Weaver.ACL.load(p.acl.id)
+    ).then((acl)->
+      acl.setUserReadAccess(user, true)
+      acl.save()
+    ).then(->
+      user.create()
+    ).then(->
+      weaver.signInWithUsername('testuser', 'testpass')
+    ).then(->
+      p.getMetadata(bundleName, appMetadata.appName)
+    ).then((metadataProject)->
+      assert.deepEqual(appMetadata, metadataProject)
+    ).then(->
+      weaver.signOut()
+    )
+    
+
   it 'should reject where trying to getMetadata for a non existing metadata related with a bundle and key', ->
     p = weaver.currentProject()
     p.getMetadata('fooBundle','barKey')


### PR DESCRIPTION
Adding test to cover: Allowing a user to read metadata from project without administration access for project

<!--
Description is not required if the Changelist.md was updated properly.

Please check the following boxes faithfully.
-->

I certify that:
- [x] The automated build passes on the branch this pull request is from
- [x] My change is documented in the Changelist.md
- [x] Any functionality additions/changes are documented in the README.md
- [x] Any new dockerimages this build depends on are properly tagged on github
- [x] I shall not merge until the travis build is green and the PR is accepted by
  another developer
- [x] I shall promptly fix/reply to comments, as I know PRs are not :fire: and
  forget
- [x] I shall keep my branch updated with any intermediate changes to the
  target branch
- [x] This is a quality PR
- [x] I got to the end of this list
