### PR TITLE
Use only major version in graph name for model bootstrap

### DIFF
--- a/Changelist.md
+++ b/Changelist.md
@@ -1,5 +1,8 @@
 # Changelist
 
+## 8.0.0
+- Only use major model version in graph name for bootstrap.
+
 ## 7.3.1
 - Set target project in booststrap query.
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lokijs": "^1.4.2",
     "pubsub-js": "^1.5.7",
     "request": "^2.82.0",
+    "semver": "^5.3.0",
     "socket.io-client": "^2.0.1",
     "socket.io-stream": "^0.9.1"
   },

--- a/src/WeaverModel.coffee
+++ b/src/WeaverModel.coffee
@@ -1,5 +1,6 @@
 cuid                 = require('cuid')
 Promise              = require('bluebird')
+semver               = require('semver')
 Weaver               = require('./Weaver')
 WeaverModelValidator = require('./WeaverModelValidator')
 _                    = require('lodash')
@@ -7,7 +8,7 @@ _                    = require('lodash')
 class WeaverModel
 
   constructor: (@definition) ->
-    @_graph = "#{@definition.name}-#{@definition.version}"
+    @_graph = "#{@definition.name}-#{semver.major(@definition.version)}"
 
   init: (includeList)->
 


### PR DESCRIPTION
Only use major model version in graph name for bootstrap

I certify that:
- [x] The automated build passes on the branch this pull request is from
- [x] My change is documented in the Changelist.md
- [x] Any functionality additions/changes are documented in the README.md
- [x] Any functionality additions/changes are _also_ documented [here](https://github.com/weaverplatform/weaver-docs/blob/master/pages/developers/reference/weaver-sdk-js.md "Weaver-docs")
- [x] Any new dockerimages this build depends on are properly tagged on github
- [x] I shall not merge until the travis build is green and the PR is accepted by
  another developer
- [x] I shall promptly fix/reply to comments, as I know PRs are not :fire: and
  forget
- [x] I shall keep my branch updated with any intermediate changes to the
  target branch
- [x] This is a quality PR
- [x] I got to the end of this list
