### PR TITLE
Allows passing of a constructor to Weaver.Relation.prototype.load

### DIFF
--- a/Changelist.md
+++ b/Changelist.md
@@ -3,6 +3,8 @@
 ## Develop
 - Add createdAt and createdBy methods to weaver node.
 - adds try/catch to JSON.parsing in cm.prototype.query
+- Allows a Constructor function to be passed to Weaver.Relation.prototype.load
+
 
 ## 8.3.0
 - Adds the selectIn method on WeaverQuery, which allows you to load any

--- a/src/WeaverRelation.coffee
+++ b/src/WeaverRelation.coffee
@@ -28,8 +28,8 @@ class WeaverRelation
   _removeRelationNodeForTarget: (oldNode) ->
     @relationNodes = @relationNodes.filter((x) -> not x.to().equals(oldNode))
 
-  load: ->
-    new Weaver.Query().hasRelationIn(@key, @owner).find()
+  load: (constructor)->
+    new Weaver.Query().hasRelationIn(@key, @owner).find(constructor)
       .then((nodes) =>
         @_addNodes(nodes...)
         @nodes

--- a/test/WeaverRelation.test.coffee
+++ b/test/WeaverRelation.test.coffee
@@ -160,6 +160,29 @@ describe 'Weaver relation and WeaverRelationNode test', ->
       expect(node.relation('relationRelation')).to.have.property('nodes').to.have.length.be(1)
     )
 
+  it 'should use the given constructor, if supplied during Weaver.Relation.prototype.load', ->
+    j = {}
+
+    class Person extends Weaver.Node
+      age: ->
+        @.get('age')
+
+    johnny = new Person('johnny')
+    tim = new Person('tim')
+
+    johnny.set('name','Johnny')
+    tim.set('name','Timothy')
+
+    johnny.relation('hasFriend').add(tim)
+    johnny.save().then(->
+      Weaver.Node.load('johnny')
+    ).then((_j)->
+      j = _j
+      j.relation('hasFriend').load(Person)
+    ).then(->
+      expect(j.relation('hasFriend').first().constructor.name).to.equal('Person')
+    )
+
   describe 'with graphs', ->
     a  = new Weaver.Node('a', 'relationWithGraph1')
     b  = new Weaver.Node('b', 'relationWithGraph1')


### PR DESCRIPTION
<!--
Description is not required if the Changelist.md was updated properly.

Please check the following boxes faithfully.
-->

I certify that:
- [x] The automated build passes on the branch this pull request is from
- [x] My change is documented in the Changelist.md
- [x] Any functionality additions/changes are documented in the README.md
- [x] Any functionality additions/changes are _also_ documented [here](https://github.com/weaverplatform/weaver-docs/blob/master/pages/developers/reference/weaver-sdk-js.md "Weaver-docs")
- [x] Any new dockerimages this build depends on are properly tagged on github
- [x] I shall not merge until the travis build is green and the PR is accepted by
  another developer
- [x] I shall promptly fix/reply to comments, as I know PRs are not :fire: and
  forget
- [x] I shall keep my branch updated with any intermediate changes to the
  target branch
- [x] This is a quality PR
- [x] I got to the end of this list
