### PR TITLE
Return a real error

### DIFF
--- a/Changelist.md
+++ b/Changelist.md
@@ -1,19 +1,19 @@
 # Changelist
 
 ## Develop
-- Rewritten subclassing mechanism of ModelClass
-- Allow specifying graph in load function on ModelClass
-- When attributes is an array, return the first instead of the array
+- Rewritten subclassing mechanism of ModelClass.
+- Allow specifying graph in load function on ModelClass.
+- When attributes is an array, return the first instead of the array.
+- Let the Legacy Error object be a JS Error instead just a {} object.
 
 ## 8.5.0
-- Allows a Constructor function to be passed to Weaver.Relation.prototype.load
-- Implements selectRelation for Weaver.ModelQuery
-- Implements Weaver.ModelRelation.prototype.load (with validity checking)
+- Allows a Constructor function to be passed to Weaver.Relation.prototype.load.
+- Implements selectRelation for Weaver.ModelQuery.
+- Implements Weaver.ModelRelation.prototype.load (with validity checking).
 
 ## 8.4.0
 - Add createdAt and createdBy methods to weaver node.
-- adds try/catch to JSON.parsing in cm.prototype.query
-
+- Adds try/catch to JSON.parsing in cm.prototype.query.
 
 ## 8.3.0
 - Adds the selectIn method on WeaverQuery, which allows you to load any

--- a/src/Error.coffee
+++ b/src/Error.coffee
@@ -1,2 +1,5 @@
 # Signature error using code and message
-module.exports = (code, message) -> {code, message}
+module.exports = (code, message) -> 
+  error = new Error(message)
+  error.code = code
+  error


### PR DESCRIPTION
Let the Legacy Error object be a JS Error instead just a {} object.

I certify that:
- [x] The automated build passes on the branch this pull request is from
- [x] My change is documented in the Changelist.md
- [x] Any functionality additions/changes are documented in the README.md
- [x] Any functionality additions/changes are _also_ documented [here](https://github.com/weaverplatform/weaver-docs/blob/master/pages/developers/reference/weaver-sdk-js.md "Weaver-docs")
- [x] Any new dockerimages this build depends on are properly tagged on github
- [x] I shall not merge until the travis build is green and the PR is accepted by
  another developer
- [x] I shall promptly fix/reply to comments, as I know PRs are not :fire: and
  forget
- [x] I shall keep my branch updated with any intermediate changes to the
  target branch
- [x] This is a quality PR
- [x] I got to the end of this list
