### PR TITLE
Use members field instead of init in model.yml

### DIFF
--- a/Changelist.md
+++ b/Changelist.md
@@ -1,6 +1,7 @@
 # Changelist
 
 ## Develop
+- Add members field as alterative to init in model.yml.
 - Remove level-fs dependency.
 - Added the test proposed by Michiel for limiting ordered queries.
 

--- a/dist/weaver-sdk.full.js
+++ b/dist/weaver-sdk.full.js
@@ -104789,27 +104789,36 @@ module.exports={
     };
 
     WeaverModel.prototype._bootstrapClasses = function(existingNodes, nodesToCreate) {
-      var ModelClass, className, classObj, i, id, itemName, len, node, ref, ref1, ref2, superClassNode, superId;
+      var ModelClass, addMember, className, classObj, i, id, itemName, j, len, len1, node, ref, ref1, ref2, ref3, superClassNode, superId;
       if (nodesToCreate == null) {
         nodesToCreate = {};
       }
       ref = this.definition.classes;
       for (className in ref) {
         classObj = ref[className];
-        if (!(classObj.init != null)) {
+        if (!((classObj.init != null) || (classObj.members != null))) {
           continue;
         }
         ModelClass = this[className];
-        ref1 = classObj.init;
-        for (i = 0, len = ref1.length; i < len; i++) {
-          itemName = ref1[i];
-          node = new ModelClass(this.definition.name + ":" + itemName, this.getGraph());
-          if (existingNodes[this.definition.name + ":" + itemName] == null) {
+        addMember = function(itemName, owner) {
+          var node;
+          node = new ModelClass(owner.definition.name + ":" + itemName, owner.getGraph());
+          if (existingNodes[owner.definition.name + ":" + itemName] == null) {
             nodesToCreate[node.id()] = node;
           } else {
             node._clearPendingWrites();
           }
-          this[className][itemName] = node;
+          return owner[className][itemName] = node;
+        };
+        ref1 = classObj.init;
+        for (i = 0, len = ref1.length; i < len; i++) {
+          itemName = ref1[i];
+          addMember(itemName, owner);
+        }
+        ref2 = classObj.members;
+        for (j = 0, len1 = ref2.length; j < len1; j++) {
+          itemName = ref2[j];
+          addMember(itemName, owner);
         }
       }
       for (className in this.definition.classes) {
@@ -104821,9 +104830,9 @@ module.exports={
           }
         }
       }
-      ref2 = this.definition.classes;
-      for (className in ref2) {
-        classObj = ref2[className];
+      ref3 = this.definition.classes;
+      for (className in ref3) {
+        classObj = ref3[className];
         if (!(classObj["super"] != null)) {
           continue;
         }

--- a/src/WeaverModel.coffee
+++ b/src/WeaverModel.coffee
@@ -230,8 +230,8 @@ class WeaverModel
           node._clearPendingWrites()
         owner[className][itemName] = node
 
-      addMember(itemName, @) for itemName in classObj.init # deprecaded
-      addMember(itemName, @) for itemName in classObj.members
+      addMember(itemName, @) for itemName in classObj.init if classObj.init? # deprecaded
+      addMember(itemName, @) for itemName in classObj.members if classObj.members? 
 
     # Now add all the nodes that are not a model class
     for className of @definition.classes

--- a/src/WeaverModel.coffee
+++ b/src/WeaverModel.coffee
@@ -219,16 +219,19 @@ class WeaverModel
   _bootstrapClasses: (existingNodes, nodesToCreate={}) ->
 
     # First create all class instances
-    for className, classObj of @definition.classes when classObj.init?
+    for className, classObj of @definition.classes when classObj.init? or classObj.members?
       ModelClass = @[className]
 
-      for itemName in classObj.init
-        node = new ModelClass("#{@definition.name}:#{itemName}", @getGraph())
-        if !existingNodes["#{@definition.name}:#{itemName}"]?
+      addMember = (itemName, owner)->
+        node = new ModelClass("#{owner.definition.name}:#{itemName}", owner.getGraph())
+        if !existingNodes["#{owner.definition.name}:#{itemName}"]?
           nodesToCreate[node.id()] = node
         else
           node._clearPendingWrites()
-        @[className][itemName] = node
+        owner[className][itemName] = node
+
+      addMember(itemName, owner) for itemName in classObj.init # deprecaded
+      addMember(itemName, owner) for itemName in classObj.members
 
     # Now add all the nodes that are not a model class
     for className of @definition.classes

--- a/src/WeaverModel.coffee
+++ b/src/WeaverModel.coffee
@@ -230,8 +230,8 @@ class WeaverModel
           node._clearPendingWrites()
         owner[className][itemName] = node
 
-      addMember(itemName, owner) for itemName in classObj.init # deprecaded
-      addMember(itemName, owner) for itemName in classObj.members
+      addMember(itemName, @) for itemName in classObj.init # deprecaded
+      addMember(itemName, @) for itemName in classObj.members
 
     # Now add all the nodes that are not a model class
     for className of @definition.classes

--- a/test-server/weaver-server-models/test-model-1.2.0.yml
+++ b/test-server/weaver-server-models/test-model-1.2.0.yml
@@ -32,6 +32,7 @@ classes:
         datatype: string
   Country:
     super: AreaSection
+    members: [Nepal]
   Construction:
     attributes:
       yearOfConstruction:

--- a/test/WeaverModel.test.coffee
+++ b/test/WeaverModel.test.coffee
@@ -195,8 +195,11 @@ describe 'WeaverModel test', ->
           new Weaver.Query().restrict('test-model:Person').find()
         ).should.eventually.have.length.be(1)
 
-      it 'should have init member after a bootstrap', ->
+      it 'should have init member after a bootstrap using deprecated init block', ->
         expect(model).to.have.property('City').to.have.property('Rotterdam').be.defined
+
+      it 'should have init member after a bootstrap using members block', ->
+        expect(model).to.have.property('Country').to.have.property('Nepal').be.defined
 
       it 'should have init member on load a rebootstrap', ->
         Weaver.Model.load(model.definition.name, model.definition.version).then((reloaded) ->


### PR DESCRIPTION
Add members field as alterative to init in model.yml.

I certify that:
- [x] The automated build passes on the branch this pull request is from
- [x] My change is documented in the Changelist.md
- [x] Any functionality additions/changes are documented in the README.md
- [x] Any functionality additions/changes are _also_ documented [here](https://github.com/weaverplatform/weaver-docs/blob/master/pages/developers/reference/weaver-sdk-js.md "Weaver-docs")
- [x] Any new dockerimages this build depends on are properly tagged on github
- [x] I shall not merge until the travis build is green and the PR is accepted by
  another developer
- [x] I shall promptly fix/reply to comments, as I know PRs are not :fire: and
  forget
- [x] I shall keep my branch updated with any intermediate changes to the
  target branch
- [x] This is a quality PR
- [x] I got to the end of this list
