### PR TITLE
Bug weav 362

### DIFF
--- a/Changelist.md
+++ b/Changelist.md
@@ -1,5 +1,8 @@
 # Changelist
 
+## develop
+- Warn if a user tries to give a sub ModelQuery to a recursive condition.
+
 ## 8.7.0
 - Replace model inclusion of models into one model with one classList
   for simplified and more powerfull usage (e.g. ModelQuery crossing

--- a/src/WeaverQuery.coffee
+++ b/src/WeaverQuery.coffee
@@ -221,7 +221,9 @@ class WeaverQuery
   _addRecursiveCondition: (op, relation, node, includeSelf) ->
     nodeId = ''
     graph = undefined
-    if node instanceof Weaver.Node
+    if node instanceof Weaver.Query
+      throw new Error('Not allowed to give sub query to recursive condition')
+    else if node instanceof Weaver.Node
       nodeId = node.id()
       graph  = node.getGraph()
     else

--- a/test/WeaverModelQuery.test.coffee
+++ b/test/WeaverModelQuery.test.coffee
@@ -332,14 +332,10 @@ describe 'WeaverModelQuery test', ->
           assert.equal(instances.length, 3)
         )
 
-      it 'should do a hasRecursiveRelationIn sub model query', ->
-        new Weaver.ModelQuery(model)
+      it 'should warn if hasRecursiveRelationIn is given a sub model query', ->
+        query = new Weaver.ModelQuery(model)
         .class(model.td.Document)
-        .hasRecursiveRelationIn('Person.signed', new Weaver.ModelQuery().class(model.td.Document))
-        .find()
-        .then((instances) ->
-          # assert.equal(instances.length, 3)
-        )
+        assert.throws(->query.hasRecursiveRelationIn('Person.signed', new Weaver.ModelQuery().class(model.td.Document)))
 
   it 'should remove the model from the query when using \'destruct\' function', ->
     q = new Weaver.ModelQuery(model)

--- a/test/WeaverModelQuery.test.coffee
+++ b/test/WeaverModelQuery.test.coffee
@@ -323,6 +323,24 @@ describe 'WeaverModelQuery test', ->
           expect(instances[0]).to.be.instanceOf(model.td.Clerk)
         )
 
+      it 'should do a hasRelationOut sub model query', ->
+        new Weaver.ModelQuery(model)
+        .class(model.Person)
+        .hasRelationOut('Person.comesFrom', new Weaver.ModelQuery(model).class(model.Country))
+        .find()
+        .then((instances) ->
+          assert.equal(instances.length, 3)
+        )
+
+      it 'should do a hasRecursiveRelationIn sub model query', ->
+        new Weaver.ModelQuery(model)
+        .class(model.td.Document)
+        .hasRecursiveRelationIn('Person.signed', new Weaver.ModelQuery().class(model.td.Document))
+        .find()
+        .then((instances) ->
+          # assert.equal(instances.length, 3)
+        )
+
   it 'should remove the model from the query when using \'destruct\' function', ->
     q = new Weaver.ModelQuery(model)
     expect(q.model).to.be.not.undefined


### PR DESCRIPTION
Warn if a user tries to give a sub ModelQuery to a recursive condition.

I certify that:
- [x] The automated build passes on the branch this pull request is from
- [x] My change is documented in the Changelist.md
- [x] Any functionality additions/changes are documented in the README.md
- [x] Any functionality additions/changes are _also_ documented [here](https://github.com/weaverplatform/weaver-docs/blob/master/pages/developers/reference/weaver-sdk-js.md "Weaver-docs")
- [x] Any new dockerimages this build depends on are properly tagged on github
- [x] I shall not merge until the travis build is green and the PR is accepted by
  another developer
- [x] I shall promptly fix/reply to comments, as I know PRs are not :fire: and
  forget
- [x] I shall keep my branch updated with any intermediate changes to the
  target branch
- [x] This is a quality PR
- [x] I got to the end of this list
