### PR TITLE
Use datatype from model

### DIFF
--- a/Changelist.md
+++ b/Changelist.md
@@ -1,7 +1,7 @@
 # Changelist
 
 ## Develop
-- Read default data type for attributes fro model.
+- Read default data type for attributes from model.
 
 ## 8.10.0
 - Add function to get data type of attribute.

--- a/Changelist.md
+++ b/Changelist.md
@@ -1,5 +1,8 @@
 # Changelist
 
+## Develop
+- Read default data type for attributes fro model.
+
 ## 8.10.0
 - Add function to get data type of attribute.
 

--- a/src/WeaverModelClass.coffee
+++ b/src/WeaverModelClass.coffee
@@ -61,10 +61,10 @@ class WeaverModelClass extends Weaver.Node
 
     if not @totalClassDefinition.attributes?
       throw new Error("#{@className} model is not allowed to have attributes")
-    if not @totalClassDefinition.attributes[field]?
+    if field not in Object.keys(@totalClassDefinition.attributes)
       throw new Error("#{@className} model is not allowed to have the #{field} attribute")
 
-    @totalClassDefinition.attributes[field].key or field
+    @totalClassDefinition.attributes[field]?.key or field
 
   _getRelationKey: (key) ->
 
@@ -164,7 +164,7 @@ class WeaverModelClass extends Weaver.Node
 
   save: (project) ->
     # Check required attributes
-    for key, attribute of @totalClassDefinition.attributes when attribute.required
+    for key, attribute of @totalClassDefinition.attributes when attribute?.required
       if not @get(key)?
         console.warn("Attribute #{key} is required for a #{@className} model")
 

--- a/src/WeaverModelClass.coffee
+++ b/src/WeaverModelClass.coffee
@@ -66,6 +66,15 @@ class WeaverModelClass extends Weaver.Node
 
     @totalClassDefinition.attributes[field]?.key or field
 
+  _getAttributeKeyDataType: (field) ->
+
+    if not @totalClassDefinition.attributes?
+      throw new Error("#{@className} model is not allowed to have attributes")
+    if field not in Object.keys(@totalClassDefinition.attributes)
+      throw new Error("#{@className} model is not allowed to have the #{field} attribute")
+
+    @totalClassDefinition.attributes[field]?.datatype or undefined
+
   _getRelationKey: (key) ->
 
     if key is @model.getInheritKey()
@@ -132,8 +141,9 @@ class WeaverModelClass extends Weaver.Node
 
   set: (field, value) ->
     key = @_getAttributeKey(field)
+    datatype = @_getAttributeKeyDataType(field)
     return null if not key?
-    super(key, value)
+    super(key, value, datatype)
 
   unset: (field, value) ->
     key = @_getAttributeKey(field)

--- a/test-server/weaver-server-models/animal-model-1.0.0.yml
+++ b/test-server/weaver-server-models/animal-model-1.0.0.yml
@@ -6,3 +6,8 @@ author:
 
 classes:
   Animal:
+  WikiPage:
+    attributes:
+      summary:
+      location:
+        datatype: 'xsd:anyURI'

--- a/test-server/weaver-server-models/test-model-1.1.2.yml
+++ b/test-server/weaver-server-models/test-model-1.1.2.yml
@@ -15,7 +15,7 @@ classes:
   Area:
     attributes:
       squareMeter:
-        datatype: integer
+        datatype: double
     relations:
       intersection:
         range: [Area]
@@ -29,7 +29,7 @@ classes:
   Construction:
     attributes:
       yearOfConstruction:
-        datatype: integer
+        datatype: double
     relations:
       buildBy:
         range: [Person]
@@ -52,7 +52,7 @@ classes:
         required: true
         datatype: string
       age:
-        datatype: integer
+        datatype: double
     relations:
       hasFriend:
         range: [Person]

--- a/test-server/weaver-server-models/test-model-1.2.0.yml
+++ b/test-server/weaver-server-models/test-model-1.2.0.yml
@@ -24,7 +24,7 @@ classes:
   Area:
     attributes:
       squareMeter:
-        datatype: integer
+        datatype: double
     relations:
       intersection:
         range: [Area]
@@ -40,7 +40,7 @@ classes:
   Construction:
     attributes:
       yearOfConstruction:
-        datatype: integer
+        datatype: double
     relations:
       buildBy:
         range: [Person]
@@ -64,7 +64,7 @@ classes:
         required: true
         datatype: string
       age:
-        datatype: integer
+        datatype: double
     relations:
       hasFriend:
         range: [Person]

--- a/test/WeaverModel.test.coffee
+++ b/test/WeaverModel.test.coffee
@@ -469,3 +469,27 @@ describe 'WeaverModel test', ->
             rel = personOne.relation('hasFriend')
             rel.to(rel.all()[0])
           )
+
+  describe 'with the animal model', ->
+    model = {}
+
+    before ->
+      Weaver.Model.load("animal-model", "1.0.0").then((m) ->
+        model = m
+        model.bootstrap()
+      )
+
+    it 'set briefly defined attributes', ->
+      page = new model.WikiPage()
+      page.set('summary', '🦒')
+      assert.equal(page.get('summary'), '🦒')
+      page.save().then(->
+        model.WikiPage.load(page.id())
+      ).then((node)->
+        assert.equal(node.get('summary'), '🦒')
+      )
+
+    it 'use the datatype specified in the model', ->
+      page = new model.WikiPage()
+      page.set('location', 'https://en.wikipedia.org/wiki/Giraffe')
+      assert.equal(page.getDataType('location'), 'xsd:anyURI')

--- a/test/WeaverModel.test.coffee
+++ b/test/WeaverModel.test.coffee
@@ -277,15 +277,19 @@ describe 'WeaverModel test', ->
       it 'should succeed setting attribuges at an extended type definition of an included model', ->
         Document = model.DeliveryNotice
         document = new Document()
-        document.set('at', 'work')
+        document.set('at', '2017-01-02')
+        expect(document.getDataType('at')).to.equal('xsd:dateTime')
         document.set('fileName', 'print.pdf')
+        expect(document.getDataType('hasFileName')).to.equal('string')
         document.save()
         .then(->
           Document.load(document.id())
         ).then((loaded)->
           expect(loaded.id()).to.equal(document.id())
-          expect(loaded.get('at')).to.equal('work')
+          expect(loaded.get('at')).to.equal(1483315200000)
           expect(loaded.get('fileName')).to.equal('print.pdf')
+          expect(loaded.getDataType('at')).to.equal('xsd:dateTime')
+          expect(loaded.getDataType('hasFileName')).to.equal('string')
         )
 
       it 'should succeed save one instance with single type', ->


### PR DESCRIPTION
Read default data type for attributes fro model.

I certify that:
- [x] The automated build passes on the branch this pull request is from
- [x] My change is documented in the Changelist.md
- [x] Any functionality additions/changes are documented in the README.md
- [x] Any functionality additions/changes are _also_ documented [here](https://github.com/weaverplatform/weaver-docs/blob/master/pages/developers/reference/weaver-sdk-js.md "Weaver-docs")
- [x] Any new dockerimages this build depends on are properly tagged on github
- [x] I shall not merge until the travis build is green and the PR is accepted by
  another developer
- [x] I shall promptly fix/reply to comments, as I know PRs are not :fire: and
  forget
- [x] I shall keep my branch updated with any intermediate changes to the
  target branch
- [x] This is a quality PR
- [x] I got to the end of this list
