### PR TITLE
Use require(fs) from a getter function so sdk loading does not fail w…

### DIFF
--- a/Changelist.md
+++ b/Changelist.md
@@ -1,5 +1,7 @@
 # Changelist
 
+- Use a getter function for fs so it doesnt fail when not required
+
 ## 8.11.0
 - Read default data type for attributes from model.
 

--- a/src/WeaverFile.coffee
+++ b/src/WeaverFile.coffee
@@ -1,4 +1,3 @@
-fs               = require('fs')
 path             = require('path')
 Promise          = require('bluebird')
 Weaver           = require('./Weaver')
@@ -6,6 +5,9 @@ WeaverError      = require('./WeaverError')
 Error            = require('./Error')
 ss               = require('socket.io-stream')
 EventEmitter     = require('events').EventEmitter
+
+getFs = ->
+  require('fs')
 
 class WeaverFile extends EventEmitter
 

--- a/src/WeaverFile.coffee
+++ b/src/WeaverFile.coffee
@@ -97,11 +97,11 @@ class WeaverFile extends EventEmitter
   # @returns {fs.Stats}
   ###
   _fileExists: (filePath) ->
-    fs.existsSync(filePath)
+    getFs().existsSync(filePath)
 
   _getFileStats: (filePath) ->
     try
-      _stats = fs.statSync(filePath)
+      _stats = getFs().statSync(filePath)
       @setName(path.basename(filePath))
       @setExtension(path.extname(filePath))
       @fileSize = _stats.size
@@ -138,7 +138,7 @@ class WeaverFile extends EventEmitter
   upload: ->
     if (File? and @filePath instanceof File) or @_fileExists(@filePath)
       stream = ss.createStream()
-      readStream = if File? and @filePath instanceof File then ss.createBlobReadStream(@filePath) else fs.createReadStream(@filePath)
+      readStream = if File? and @filePath instanceof File then ss.createBlobReadStream(@filePath) else getFs().createReadStream(@filePath)
       _uploadedBytes = 0
 
       readStream.on('data', (chunk) =>
@@ -168,7 +168,7 @@ class WeaverFile extends EventEmitter
       .downloadFile(@fileId)
       .then((stream) =>
         _downloadedBytes = 0
-        writeStream = fs.createWriteStream(@filePath)
+        writeStream = getFs().createWriteStream(@filePath)
 
         stream.on('data', (chunk) =>
           _downloadedBytes += chunk.length

--- a/src/WeaverPlugin.coffee
+++ b/src/WeaverPlugin.coffee
@@ -1,7 +1,8 @@
 Weaver = require('./Weaver')
 ss     = require('socket.io-stream')
-fs     = require('fs')
 
+getFs = ->
+  require('fs')
 
 class WeaverPlugin
 
@@ -28,9 +29,9 @@ class WeaverPlugin
           # File is a special parameter name which causes a socket stream to
           # be created and its always required
 
-          if(File? and file instanceof File) or fs.existsSync(file)
+          if(File? and file instanceof File) or getFs().existsSync(file)
             stream = ss.createStream()
-            readStream = if File? and file instanceof File then ss.createBlobReadStream(file) else fs.createReadStream(file)
+            readStream = if File? and file instanceof File then ss.createBlobReadStream(file) else getFs().createReadStream(file)
             readStream.pipe(stream)
             payload['file'] = stream
           else


### PR DESCRIPTION
…hen fs is not required

<!--
Description is not required if the Changelist.md was updated properly.

Please check the following boxes faithfully.
-->

I certify that:
- [x] The automated build passes on the branch this pull request is from
- [x] My change is documented in the Changelist.md
- [x] Any functionality additions/changes are documented in the README.md
- [ ] Any functionality additions/changes are _also_ documented [here](https://github.com/weaverplatform/weaver-docs/blob/master/pages/developers/reference/weaver-sdk-js.md "Weaver-docs")
- [x] Any new dockerimages this build depends on are properly tagged on github
- [x] I shall not merge until the travis build is green and the PR is accepted by
  another developer
- [x] I shall promptly fix/reply to comments, as I know PRs are not :fire: and
  forget
- [x] I shall keep my branch updated with any intermediate changes to the
  target branch
- [x] This is a quality PR
- [x] I got to the end of this list
