### PR TITLE
can't use different references of the same model for `modelRelation.load`

### DIFF
--- a/Changelist.md
+++ b/Changelist.md
@@ -1,11 +1,14 @@
 # Changelist
 
+## Develop
+- changed model class comparison to evaluate against constructor name, instead of doing object comparison between the two constructors (wasn't otherwise able to use multiple references to the same model)
+
 ## 9.1.0
 - Add wpath support with initial two filters.
 
 ## 9.0.0
 - Adds Weaver.ModelClass.getSuperClass() method.
-- Changes Weaver.ModelQuery().prototype.class() method to return valid for 
+- Changes Weaver.ModelQuery().prototype.class() method to return valid for
   all subclasses of a model class, as well as the class itself.
 
 ## 8.11.1

--- a/src/WeaverModelRelation.coffee
+++ b/src/WeaverModelRelation.coffee
@@ -25,7 +25,7 @@ class WeaverModelRelation extends Weaver.Relation
 
   _checkCorrectConstructor: (constructor) ->
     for range in @owner.getRanges(@modelKey)
-      return true if @model.classList[range] is constructor
+      return true if @model.classList[range].className is constructor.className
     throw new Error("Model #{@className} is not allowed to have relation #{@modelKey} to instance"+
       " of def #{constructor.className}.")
 

--- a/src/WeaverModelRelation.coffee
+++ b/src/WeaverModelRelation.coffee
@@ -25,7 +25,7 @@ class WeaverModelRelation extends Weaver.Relation
 
   _checkCorrectConstructor: (constructor) ->
     for range in @owner.getRanges(@modelKey)
-      return true if @model.classList[range].className is constructor.className
+      return true if @model.classList[range].className is constructor.className and range is constructor.classId()
     throw new Error("Model #{@className} is not allowed to have relation #{@modelKey} to instance"+
       " of def #{constructor.className}.")
 

--- a/test/WeaverModel.test.coffee
+++ b/test/WeaverModel.test.coffee
@@ -47,11 +47,16 @@ describe 'WeaverModel test', ->
 
   describe 'with a loaded model', ->
     model = {}
+    model2 = {}
 
     before ->
       Weaver.Model.load("test-model", "1.2.0").then((m) ->
         model = m
         model.bootstrap()
+      ).then(->
+        Weaver.Model.load("test-model", "1.2.0")
+      ).then((m) ->
+          model2 = m
       )
 
     it 'should return the superClasses', ->
@@ -259,6 +264,13 @@ describe 'WeaverModel test', ->
           expect(node).to.be.instanceOf(model.Office)
           expect(node.getGraph()).to.equal('some-graph')
           expect(node.relation('placedIn').first().id()).to.equal(c.id())
+        )
+
+      it 'should be able to load some recently added relations', ->
+        chief = new model.Person('chief')
+        chief.relation('worksIn').add(new model2.Office())
+        chief.save().then(->
+          chief.relation('worksIn').load(model2.Office)
         )
 
       it 'should succeed saving with type definition that is bootstrapped', ->


### PR DESCRIPTION
<!--
Description is not required if the Changelist.md was updated properly.

Please check the following boxes faithfully.
-->

I certify that:
- [x] The automated build passes on the branch this pull request is from
- [x] My change is documented in the Changelist.md
- [x] Any functionality additions/changes are documented in the README.md
- [ ] Any functionality additions/changes are _also_ documented [here](https://github.com/weaverplatform/weaver-docs/blob/master/pages/developers/reference/weaver-sdk-js.md "Weaver-docs")
- [x] Any new dockerimages this build depends on are properly tagged on github
- [x] I shall not merge until the travis build is green and the PR is accepted by
  another developer
- [x] I shall promptly fix/reply to comments, as I know PRs are not :fire: and
  forget
- [x] I shall keep my branch updated with any intermediate changes to the
  target branch
- [x] This is a quality PR
- [x] I got to the end of this list
