### PR TITLE
Weav 379 upload multipel files when no bucket

### DIFF
--- a/test-server/docker-compose.yml
+++ b/test-server/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     - "9000:9000"
 
   weaver-server:
-    image: sysunite/weaver-server:3.15.1-beta.0
+    image: sysunite/weaver-server:3.15.1
     expose:
     - "9487"
     ports:

--- a/test-server/docker-compose.yml
+++ b/test-server/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     - "9000:9000"
 
   weaver-server:
-    image: sysunite/weaver-server:3.14.4-alpha.1
+    image: sysunite/weaver-server:3.15.1-beta.0
     expose:
     - "9487"
     ports:

--- a/test/WeaverFile.test.coffee
+++ b/test/WeaverFile.test.coffee
@@ -82,24 +82,30 @@ describe 'WeaverFile test', ->
         expect(files.length).to.be.at.least(1)
       )
 
-  it 'should support big simultanious upload', ->
+  it 'should support big simultanious upload for a new project', ->
     @skip() if window?
     @timeout(15000)
-    @listSize = 6
+    listSize = 20
 
-    files = (new Weaver.File(path.join(__dirname,'../icon.png')).upload() for i in [0..@listSize-1])
+    p = weaver.currentProject()
+    test = new Weaver.Project()
+    test.create().then(->
+      weaver.useProject(test)
+    ).then(->
+      
+      files = (new Weaver.File(path.join(__dirname,'../icon.png')).upload() for i in [0..listSize-1])
 
-    # Make sure bucket exists
-    Promise.all(files)
-    .then((storedFiles) =>
-      console.log storedFiles.length
-      expect(storedFiles.length).to.equal(@listSize)
-      expect(file.id()).to.exist for file in storedFiles
-      Weaver.File.list()
-    ).then((list) =>
-      expect(list.length).to.equal(@listSize)
+      Promise.all(files)
+      .then((storedFiles) =>
+        expect(storedFiles.length).to.equal(listSize)
+        expect(file.id()).to.exist for file in storedFiles
+        Weaver.File.list()
+      ).then((list) =>
+        expect(list.length).to.equal(listSize)
+        test.destroy()
+        weaver.useProject(p)
+      )
     )
-
 
   it 'should deny access when uploading with unauthorized user', ->
     @skip() if window?

--- a/test/WeaverFile.test.coffee
+++ b/test/WeaverFile.test.coffee
@@ -82,17 +82,22 @@ describe 'WeaverFile test', ->
         expect(files.length).to.be.at.least(1)
       )
 
-  it 'should support simultanious upload', ->
+  it 'should support big simultanious upload', ->
     @skip() if window?
     @timeout(15000)
-    file = new Weaver.File(path.join(__dirname,'../icon.png'))
-    file2 = new Weaver.File(path.join(__dirname,'../icon.png'))
+    @listSize = 6
 
-    #Make sure bucket exists
-    Weaver.File.list().then(->
-      Promise.all([file.upload(), file2.upload()])
-    ).then((storedFiles) ->
-      expect(storedFiles.length).to.equal(2)
+    files = (new Weaver.File(path.join(__dirname,'../icon.png')).upload() for i in [0..@listSize-1])
+
+    # Make sure bucket exists
+    Promise.all(files)
+    .then((storedFiles) =>
+      console.log storedFiles.length
+      expect(storedFiles.length).to.equal(@listSize)
+      expect(file.id()).to.exist for file in storedFiles
+      Weaver.File.list()
+    ).then((list) =>
+      expect(list.length).to.equal(@listSize)
     )
 
 


### PR DESCRIPTION
Support uploading multiple files when there is no bucket yet

I certify that:
- [x] The automated build passes on the branch this pull request is from
- [x] My change is documented in the Changelist.md
- [x] Any functionality additions/changes are documented in the README.md
- [x] Any functionality additions/changes are _also_ documented [here](https://github.com/weaverplatform/weaver-docs/blob/master/pages/developers/reference/weaver-sdk-js.md "Weaver-docs")
- [x] Any new dockerimages this build depends on are properly tagged on github
- [x] I shall not merge until the travis build is green and the PR is accepted by
  another developer
- [x] I shall promptly fix/reply to comments, as I know PRs are not :fire: and
  forget
- [x] I shall keep my branch updated with any intermediate changes to the
  target branch
- [x] This is a quality PR
- [x] I got to the end of this list
