### PR TITLE
Weav 271 warn when no model

### DIFF
--- a/Changelist.md
+++ b/Changelist.md
@@ -1,5 +1,8 @@
 # Changelist
 
+## Develop
+- Throw a descriptive error when no model is supplied as agument for a ModelQuery
+
 ## 11.0.2
 - Fix bug in allowed relations when two different modelKeys map to the same key
 

--- a/src/WeaverModelQuery.coffee
+++ b/src/WeaverModelQuery.coffee
@@ -6,7 +6,7 @@ class WeaverModelQuery extends Weaver.Query
 
   constructor: (context = Weaver.currentModel(), target) ->
     super(target)
-    @context = context
+    @context = context or throw new Error('Please specify a model for the ModelQuery either by supplying an argument or setting Weaver.useModel(model)')
     @model = context.model
     @keyMappingDisabled = false
 

--- a/test/WeaverModelQuery.test.coffee
+++ b/test/WeaverModelQuery.test.coffee
@@ -417,3 +417,18 @@ describe 'WeaverModelQuery test', ->
     q = new Weaver.ModelQuery(model)
     q.contains('Passport.fileName', 'someFilename')
     expect(q._conditions['hasFileName']).to.be.not.undefined
+
+  it 'should allow omitting the model argument when there is a default model', ->
+    Weaver.Model.load('test-model', '1.2.0')
+    .then((model)->
+      Weaver.useModel(model)
+      new Weaver.ModelQuery()
+      .restrict('jondoeid')
+      .find()
+    ).then((instances)->
+      expect(instances).to.have.length.be(1)
+    )
+
+  it 'should throw an error when no model is selected', ->
+    expect(->new Weaver.ModelQuery()).to.throw('Please specify a model for the ModelQuery')
+

--- a/test/WeaverModelQuery.test.coffee
+++ b/test/WeaverModelQuery.test.coffee
@@ -430,5 +430,6 @@ describe 'WeaverModelQuery test', ->
     )
 
   it 'should throw an error when no model is selected', ->
+    Weaver.useModel(null)
     expect(->new Weaver.ModelQuery()).to.throw('Please specify a model for the ModelQuery')
 


### PR DESCRIPTION
Throw a descriptive error when no model is supplied as agument for a ModelQuery

I certify that:
- [x] The automated build passes on the branch this pull request is from
- [x] My change is documented in the Changelist.md
- [x] Any functionality additions/changes are documented in the README.md
- [x] Any functionality additions/changes are _also_ documented [here](https://github.com/weaverplatform/weaver-docs/blob/master/pages/developers/reference/weaver-sdk-js.md "Weaver-docs")
- [x] Any new dockerimages this build depends on are properly tagged on github
- [x] I shall not merge until the travis build is green and the PR is accepted by
  another developer
- [x] I shall promptly fix/reply to comments, as I know PRs are not :fire: and
  forget
- [x] I shall keep my branch updated with any intermediate changes to the
  target branch
- [x] This is a quality PR
- [x] I got to the end of this list
